### PR TITLE
Videochat design changes for 2021 [Closes #592][#593]

### DIFF
--- a/server/src/rooms/data/roomData.json
+++ b/server/src/rooms/data/roomData.json
@@ -17,7 +17,7 @@
     "displayName": "Endless Oatmeal",
     "shortName": "Oatmeal",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "Wow, this place is... something. You're in an endless pool of oatmeal, stretching from horizon to horizon. The area near you has some raisins in it. A little further off you can see that the surface of the oatmeal is dusted with cinnamon. But it's all oatmeal. The only features of note are within the small island you find yourself on, a large, looping pile of loose, dry oats in the shape of a figure 8. Floating in each hollow of the 8 is a bowl of cereal; it looks like the kind where each piece is a letter of the alphabet? Perhaps they have a message for you.",
     "riddles": [
       "Some call me a game;<br/>Some call me a chore;<br/>Some call me a risk;<br/>Some call me a bore;<br/>Without me you cannot,<br/>Know what is in store;<br/>'Til you quaff that potion,<br/>You will not be sure.",
@@ -42,7 +42,7 @@
     "displayName": "Division Leaders 3Q21 - Grab Your Swag!",
     "shortName": "the chaos pit swag tables",
     "hidden": true,
-    "noMediaChat": true,
+
     "description": "A banner is strung above a cheap plastic foldable table. Heaped on the table are what appear to be Orbs of Zot. Another, even bigger pile contains what must be thousands of Amulets of Yendor, and the third \"pile\" is a single, already-opened box of 8 crayons. The demon is totally ignoring you; you can very easily get an [[Orb of Zot->item]] or [[Amulet of Yendor->item]], or even that [[box of crayons->item]] if that's your fancy.<br/><br/>You can also head [[back there->wildchaospit]] before you go, or go straight to the [[pentagrams->pitPentagrams]] they were gesturing at."
   },
   "naga": {
@@ -50,7 +50,6 @@
     "displayName": "Unconferencing: Naga Den",
     "shortName": "Unconferencing: Naga",
     "description": "This is an unconferencing room. The door swings open with a push, not requiring you to use your hands. The floor is sandy and warm to the touch. Piled in a corner are Roguelike Celebration socks from various years, looking entirely unused for some reason.<br/><br/>We encourage you to use this space to talk \"face-to-face\" using <a href=\"https://us02web.zoom.us/j/84946016673?pwd=OTNRWjZKdmx0RGthWVVueHlqUm84Zz09\" target=\"_blank\">the Zoom meeting for this room</a>, which you can access at any time during the conference. (Passcode 046256)<br/><br/>The other unconferencing rooms are [[cockatrice]], [[dragon]], [[skeleton]], [[tengu]], and [[yak]]. Or you can climb the stairs back up to the [[unconferencing lobby->unconference]].",
-    "noMediaChat": true,
     "hasNoteWall": true
   },
   "hall": {
@@ -72,7 +71,6 @@
     "displayName": "A Major Consultation with the Oracle",
     "shortName": "the inside of the Oracle Temple",
     "hidden": true,
-    "noMediaChat": true,
     "description": "The Oracle of Delphi - a truly beautiful @ in shimmering blue - perks up at your presence.<br/><br/>\"Oh, hi there! Sorry about all the mess, the fountain liquids all shifting, the map being all out of true - some ridiculous chaos demons have been messing with the fabric of space around here. They've scattered a dozen riddles around - some even within the useful spaces, those poor dogs - which apparently build some kind of code phrase that's important to them.<br/><br/>If you figure a riddle out, I think you can use that \"/go\" invocation you used to get here to see what visions it brings you. I suspect things might be finicky when it comes to translocation magic - again, chaos - but I *believe* my centaurs got things to a point where all lowercase components work.<br/><br/>Hopefully if you figure that code phrase out and /go to them, maybe you'll get some kind of explaination, or at least a neat bauble...? I dunno, I'm kinda stuck here. But good luck!\"<br/><br/> If you want a space where you can talk with others about the puzzles without spoiling them, feel free to chat [[nearby->spoil]]. You can return to the [[fountains->oracle]]."
   },
   "oracle": {
@@ -80,7 +78,6 @@
     "displayName": "Outside the Oracle of Delphi",
     "shortName": "the Oracle of Delphi",
     "hidden": true,
-    "noMediaChat": true,
     "description": "This usually peaceful space is decorated with burbling fountains, stately marble columns, and finely carved statues of centaurs in various poses. Strangely though, the fountains aren't uniformly flowing water - some are filled with strange gooey substances, at least one looks like it's full of cheese sauce. A hastily scrawled sign stuck to one of the fountains says \"The Oracle Is In\", with an arrow to a [[small temple->majorConsultation]]. On a pedestal rests a bowl of fortune cookies labeled [[\"minor consultations\"->getFortune]]. Alternately, you can go back to the [[dungeon you came from->ascii]]."
   },
   "hiddenPortalRoom": {
@@ -88,9 +85,7 @@
     "displayName": "Portal Room",
     "shortName": "the portal room",
     "description": "In the center of the room is a shimmering portal. Next to the portal is a pedestal with an open book. To your right is a table with a sign hung behind it, reading \"Lending Table\" in flowery wizard script. On the table you can see [[a wand of digging->item]], [[a Proof of Stremf->item]], [[a pair of seven league boots->item]], and [[Planepacked->item]], the legendary limestone statue.<br/><br/>Once you've finished here, you can [[leap into the shimmering portal->hall]]",
-    "specialFeatures": [
-      "FULL_ROOM_INDEX"
-    ],
+    "specialFeatures": ["FULL_ROOM_INDEX"],
     "hidden": true
   },
   "timeMachine": {
@@ -108,7 +103,7 @@
     "displayName": "The Forest of Wands",
     "shortName": "The Wand",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "You're transported to a grove of impossibly tall silver trees. Golden leaves the size of your head float gently down from distant boughs. The air feels thick with some kind of energy that makes your hair stand on end and your teeth buzz. An alter of hewn stone sits ahead of you, and on it rests a single Tarot card depicting a hand emerging from a thundercloud to grasping a single branch: the Ace of Wands. Someone has affixed three more tarot cards to trees lining the clearing with brass pins: the Five of Swords, the Nine of Pentacles and the Page of Cups. On closer inspection, there's a riddle scrawled on each of these cards.",
     "riddles": [
       "Be careful, brave adventurer, should you and I e'er meet;\nFor e'en should you vanquish me (to be clear: quite the feat);\nI shan't e'en then be through with you; I'll catch you unawares;\nTake caution all who'd wield my flesh: thine enemy is stairs.",
@@ -121,7 +116,6 @@
     "displayName": "Theater",
     "shortName": "the theater",
     "description": "A stage, confusingly decorated with Halloween skulls and streamers. There are a few dozen flimsy metal chairs you can sit in, plus some comfy couches in the back. <br/><br/>You can return to the [[hall]]. Or if you'd like to speak to one of our speakers after their talk, you can head to breakout rooms: [[Warrior->warrior]], [[Mage->mage]], [[Rogue->rogue]], or [[Tourist->tourist]]. (Check the \"Happening Now\" button on the left for speaker room assignments!)<br/><br/><a href=\"stream.html\" onClick=\"window.open('stream.html#' + window.getComputedStyle(document.body).getPropertyValue('background-color'), 'stream', 'width=560,height=460'); return false\">Pop Out Stream</a>. <a href=\"https://www.streamtext.net/player?event=RoguelikeCelebration\" target=\"_blank\">Pop Out Live Captions</a>.<br/>",
-    "noMediaChat": true,
     "hasNoteWall": true,
     "noteWallData": {
       "roomWallDescription": "There is a whiteboard set up to the side with \"SPEAKER QUESTIONS\" written at the top. \"Questions for speakers not questions from speakers!\" is hastily scrawled below it.",
@@ -136,7 +130,7 @@
     "displayName": "The Savescum Chessboard",
     "shortName": "savescum",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "You are in the corner of a giant chess board. The walls of the room containing it lavishly decorated in the style of a medieval court, with portraits of an imperious-looking king and queen and a bunch of minor nobility you can't place. In the center of the chessboard you see an Orb on a pedestal; your adventuring reflex immediate kicks in: an Orb is to collect, after all. Between you and the Orb, however, are dozens of chess pieces larger than yourself, scattered about the board as if midway through a game.<br/><br/>You take a few steps towards the Orb and nothing happens. Maybe this won't be too complicated? But on your next step, a Knight swoops in and knocks you down; you've been Captured. You eye the square you started at, yards back. Why walk all the way? You just return to the last safe square you were at and try a different path. It works! You've gone another few steps when your foot lands on a white square and a Bishop you hadn't noticed swoops in from the far side of the board and caroms into you. Ok, well, you're *definitely* not going to go back to the starting square now; you just slink back to where you were before the Bishop attack and try again.<br/><br/>Thus you make your way, in fits and starts, to the Orb, backing up to safe spaces when you encounter danger to feel out a new path. Eventually you arrive, but the Orb seems to be attached to the pedestal through a mechanism unknown to you. Gazing into it, you see that at its heart there's an elaborately carved crystal in the shape of spiral: it's a 9."
   },
   "railing": {
@@ -156,7 +150,6 @@
     "displayName": "The Wild Chaos Pit",
     "shortName": "wild chaos pit",
     "hidden": true,
-    "noMediaChat": true,
     "description": "You invoke the spell you've discovered and the world melts around you. You had been standing in the conference hall; now you're floating in an endless abyss. No, that's not right: you're *falling through* it, from the material plane to a realm of pure, elemental chaos. Wild, fantastical shapes emerge from swirling mists as you descend, nightmares made real that advance upon you only to be torn apart and dissolve back into mist. Eventually your hellish journey ends and you land, with essentially no fanfare, at the very center of the Wild Chaos Pit.</br></br>You're in a small room with off-white walls and no exits. There's a desk with some kind of demon in a poorly fitted suit, typing away on a computer terminal. It spares you a glance as you enter and greets you in a droning monotone. \"Oh, hello. Welcome to the Wild Chaos Pit. Cower in fear at our terrifying splendor.\" The demon gestures to an inspiration poster of a skeleton hanging from a telephone wire as evidence of this. \"We would like to take this opportunity to thank you for your assistance in our mission. The forces of Chaos have had a great quarter, and we could not have succeeded in meeting our operational goals without the dedication and support of you, the player. Please avail yourself of our fabulous facilities before returning to your realm.\" The demon, their speech finished, turns their attention back to the computer. Without looking up, they drone: \"Oh, my apologies. Before returning to your realm, *mortal*.\"</br></br>Apart from the desk and skeleton poster, the room is minimally furnished. There's some sort of [[swag table->pitSwag]] you can investigate. \"Exit through the gift shop,\" says the demon. \"Emphasis on exit.\" They nod at the other end of the room, where [[four pentagrams->pitPentagrams]] are etched into the floor.",
     "hasNoteWall": true,
     "noteWallData": {
@@ -172,7 +165,7 @@
     "displayName": "The Permadeath Dig",
     "shortName": "permadeath",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "You have a sudden vision of archaeological dig, the sun hot above you, the remnants of ancient Babylon below. On a table in front of you, one of your research assistants has laid out a series of stone tablets. The medium was a demanding one for the written word; any mistake would be immutable, as eternal as the stone itself. The original author seemed to be working towards something, but each time made a mistake in the telling and was forced to start over. Despite this, you notice differences in each attempt; the stories, despite the same goal, diverged as the stone carver repeatedly attempted to complete their tale. \"How many tablets did we find?\" you ask your assistant. The grad student responds, \"We found 10, professor.\""
   },
   "skeleton": {
@@ -180,7 +173,6 @@
     "displayName": "Unconferencing: Skeleton Clubhouse",
     "shortName": "Unconferencing: Skeleton",
     "description": "This is an unconferencing room. The walls are plastered with unconventional [[motivational posters->readPoster]]. A mini-fridge hums in the corner, but when you pop it open is stocked only with jugs of milk.<br/><br/>We encourage you to use this space to talk \"face-to-face\" using <a href=\"https://us02web.zoom.us/j/87320810860?pwd=WmhISXBza1hPZ1k3MFhDdDZwVEtPQT09\" target=\"_blank\">the Zoom meeting for this room</a>, which you can access at any time during the conference. (Passcode 799782)<br/><br/>The other unconferencing rooms are [[cockatrice]], [[dragon]], [[naga]], [[tengu]], and [[yak]]. Or you can climb the stairs back up to the [[unconferencing lobby->unconference]].",
-    "noMediaChat": true,
     "hasNoteWall": true
   },
   "ascii": {
@@ -190,8 +182,7 @@
     "description": "The entire square tile you are standing on vibrates, and the world around you changes - you have entered an older time. The walls are made out of #, you can easily see the . at your feet, and your old powers of audio and video do not work here.</br></br>A row of twelve headstones stand in a line. They are all blank, except for the seventh, which is engraved with '7 - A'. Behind them stand four statues - a hobbit, a tree, a crocodile, and a more abstract one of unhewn stone. Each has a riddle engraved in its base.</br></br>A door behind you leads through various twisty passages; despite them all looking alike, you know one heads to the [[Oracle of Delphi->oracle]], and then a set heads back to the [[Space Hangar->sfHub]].",
     "hasNoteWall": true,
     "hidden": true,
-    "noMediaChat": true,
-    "noteWallData": {
+    "noteWalData": {
       "roomWallDescription": "Do you want your possessions identified?",
       "noteWallButton": "y/n/q",
       "addNoteLinkText": "Tell a story",
@@ -210,7 +201,6 @@
     "displayName": "Unconferencing Lobby",
     "shortName": "the unconferencing lobby",
     "description": "Winding corridors lead to a large dungeon-like room. Sticky notes and magic markers are piled up on tables along with assorted adventuring gear. White banners with blocky black text label several hallways leading to the unconferencing rooms - [[cockatrice]], [[dragon]], [[naga]], [[skeleton]], [[tengu]], and [[yak]]. You can also return back to the [[hall]].",
-    "noMediaChat": true,
     "hasNoteWall": true,
     "noteWallData": {
       "roomWallDescription": "One wall of this room is taken up by a large whiteboard titled \"UNCONFERENCE TOPIC SUGGESTIONS!\" Smaller font clarifies \"Write what you want to chat with others about, and upvote topics you find interesting. Moderators will assign the top six topics rooms, 5 minutes into each unconference block. Have fun!\"",
@@ -251,9 +241,7 @@
     "displayName": "The Secondarily-Hydrogenated Oxygen Weighted Emulsion Remover",
     "shortName": "the S.H.O.W.E.R.",
     "description": "There's a large glass object here, embedded in a cage of tubes and wires. It's almost like a giant vacuum tube or a huge beaker closed off at the top, except that there's an opening in the side large enough to step through.<br/><br/>Or simply [[return->dyes]].",
-    "specialFeatures": [
-      "DULL_DOOR"
-    ]
+    "specialFeatures": ["DULL_DOOR"]
   },
   "exploreHub": {
     "id": "exploreHub",
@@ -281,7 +269,7 @@
     "displayName": "Tome of Identify: It Is What It Is",
     "shortName": "Identify",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "You're in a room dominated by a single large tome on a table. On the cover of the book, letters inlaid with gold leaf read \"It Is What It Is, Part 2: Clear Potion through Frotz, Scroll of\". Flipping through the book you find it's filled with thousands of tables allowing you to look up any object based on its weight, appearance, general shape, and what merchants might offer for it (so long as the item is in its alphabetical range). You're struck with the notion that some might seek to sit down and memorize the thing in full."
   },
   "loungeDungeonClosetShoePath": {
@@ -317,14 +305,12 @@
     "displayName": "Unconferencing: Cockatrice Containment",
     "shortName": "Unconferencing: Cockatrice",
     "description": "This is an unconferencing room. A table labelled \"NECESSARY PRECAUTIONS\" in huge block letters has buckets for gloves, earplugs, and lizards... but troublingly all are empty. It's probably fine. There's a statue of a hapless adventurer, cunningly carved in granite that captures their likeness midway through an apparent tumble down a flight of steps. The statue is labeled \"Newb Descending a Staircase #5.\"<br/><br/>We encourage you to use this space to talk \"face-to-face\" using <a href=\"https://us02web.zoom.us/j/87385558857?pwd=UHREZEgyRjQ1L2dta1N1amdWMmF6dz09\" target=\"_blank\">the Zoom meeting for this room</a>, which you can access at any time during the conference. (Passcode 270805)<br/><br/>The other unconferencing rooms are [[dragon]], [[naga]], [[skeleton]], [[tengu]], and [[yak]]. Or you can climb the stairs back up to the [[unconferencing lobby->unconference]].",
-    "noMediaChat": true,
     "hasNoteWall": true
   },
   "robots": {
     "id": "robots",
     "displayName": "Robot Fabrication Lab",
     "shortName": "the robot lab",
-    "noMediaChat": true,
     "description": "This room is dominated by the quiet hum of machinery doing what it was designed to with minimal fuss and expertly crafted efficiency. Sprockets are being socketed in in one device. A robot arm picks up the socketed sprocket and passes it to a CNC spot welder, which welds it closed. The locked socketed sprockets are conveyed into an opening on the biggest machine, just one of many components for [[the robots->watchRobot]] produced at this fab lab. The entire dance is carried out with a ballet-like elegance, not a movement wasted. It's aggressively, profoundly satisfying. When you feel ready, you can go back to the [[Space Hangar->sfHub]]."
   },
   "yak": {
@@ -332,7 +318,6 @@
     "displayName": "Unconferencing: Yak Pen",
     "shortName": "Unconferencing: Yak",
     "description": "This is an unconferencing room. The smell in here is... a lot. A sign at the entrance pleads \"Please, no shaving!\" A table is set up as if to offer refreshments but atop it are just blocks of solid salt, carved into abstract shapes by the licking of very large tongues.<br/><br/>We encourage you to use this space to talk \"face-to-face\" using <a href=\"https://us02web.zoom.us/j/82669162828?pwd=L3kxdkhHUjRqQWdFbU11Y0tocGlBdz09\" target=\"_blank\">the Zoom meeting for this room</a>, which you can access at any time during the conference. (Passcode 379872)<br/><br/>The other unconferencing rooms are [[cockatrice]], [[dragon]], [[naga]], [[skeleton]], and [[tengu]]. Or you can climb the stairs back up to the [[unconferencing lobby->unconference]].",
-    "noMediaChat": true,
     "hasNoteWall": true
   },
   "transmute": {
@@ -360,7 +345,6 @@
     "displayName": "Unconferencing: Dragon's Lair",
     "shortName": "Unconferencing: Dragon",
     "description": "This is an unconferencing room. It's a bit difficult to move around as the floor is stacked with piles of coins, gems, and scales. Passive aggressive post-its outline an outstanding series of arguments about which colour is superior and therefore deserves the most floor space. Best not to get involved.<br/><br/>We encourage you to use this space to talk \"face-to-face\" using <a href=\"https://us02web.zoom.us/j/84647465158?pwd=Z1dsQ2lvK0Fta3I0RzR4bXNMaEU3UT09\" target=\"_blank\">the Zoom meeting for this room</a>, which you can access at any time during the conference. (Passcode 299447)<br/><br/>The other unconferencing rooms are [[cockatrice]], [[naga]], [[skeleton]], [[tengu]], and [[yak]]. Or you can climb the stairs back up to the [[unconferencing lobby->unconference]].",
-    "noMediaChat": true,
     "hasNoteWall": true
   },
   "tengu": {
@@ -368,7 +352,6 @@
     "displayName": "Unconferencing: Tengu Workshop",
     "shortName": "Unconferencing: Tengu",
     "description": "This is an unconferencing room. Feathers of all sizes and hues are scattered through the room, and the seating options include traditional chairs as well as perches. Do take care sitting down - whoopie cushions, wet paint, and similar mischief is to be expected here.<br/><br/>We encourage you to use this space to talk \"face-to-face\" using <a href=\"https://us02web.zoom.us/j/82349098446?pwd=QjA5Q2pYV1pjMUxkQjNwMmFUTmMrQT09\" target=\"_blank\">the Zoom meeting for this room</a>, which you can access at any time during the conference. (Passcode 809263)<br/><br/>The other unconferencing rooms are [[cockatrice]], [[dragon]], [[naga]], [[skeleton]], and [[yak]]. Or you can climb the stairs back up to the [[unconferencing lobby->unconference]].",
-    "noMediaChat": true,
     "hasNoteWall": true
   },
   "mage": {
@@ -402,7 +385,6 @@
     "displayName": "Four Pentagrams",
     "shortName": "the pentagrams",
     "hidden": true,
-    "noMediaChat": true,
     "description": "One pentagram looks very [[high tech->pentagramHighTech]]. Another is more [[minimalist and austere->pentagramMinimalist]]. A third is [[wavey and almost comical->pentagramComical]]. The last pentagram seems somehow [[extremely normal->pentagramNormal]].<br/><br/>As the demon said, these are the exits. Now that you know the phrase, you could get back here when you wanted. But maybe you want to check out that [[swag table->pitSwag]] or [[logbook->wildchaospit]] before you go."
   },
   "rogue": {
@@ -430,16 +412,14 @@
     "displayName": "An incredibly complicated machine",
     "shortName": "an incredibly complicated machine",
     "description": "You find yourself in a space dominate by an incredibly complicated machine. Arcs of aetheric energy jump between leyden jars, and what appears to be an enormous water clock is driving an incomprehensible mass of gearwork. At the center of it all, like a tiny egg in rather large nest, is a simple chair. A frenetic individual in a white coat, their features obscured by thick googles and safety gear is tightening a bolt on the machine when you walk up.<br/><br/>Or maybe you should just [[leave->dyes]].",
-    "specialFeatures": [
-      "RAINBOW_DOOR"
-    ]
+    "specialFeatures": ["RAINBOW_DOOR"]
   },
   "dungeon": {
     "id": "dungeon",
     "displayName": "The Dungeon's Maze",
     "shortName": "The Dungeon",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "You find yourself in a maze of twisty little passages, all alike. From down some of the corridors you can hear distant echoing noises that suggest there may be more than just riddle-solving adventurers lurking in these halls. The dungeon is damp, and dark, and your torch only illuminates a few dozen feet away from you before the darkness takes over. An shelf set into the wall here holds 4 candles. There are also two tomes. The leather cover of one has what appears to be a tower embossed in it; the other is absolutely blank.",
     "riddles": [
       "Tis not thy hands that move, but mine;<br/>To beat the march of death.<br/>And while I shan't count minutes;<br/>Thou shalt count thine every breath.<br/>A goblin's dirk's is deadly, yes-<br/>But once they're slain, benign.<br/>I'll motivate thy progress, friend:<br/>Starvation takes its time.",
@@ -451,7 +431,7 @@
     "displayName": "The Losing Fortress",
     "shortName": "losing",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "You find yourself in the remains of a once-might fortress of the dwarves. Signs of struggle are everywhere. Struggle, and a truly staggering amount of lava. Really, whose idea was all the lava? You get the sense that maybe it was meant to be a defensive measure but it clearly backfired spectacularly. Oh well, it was probably Fun while it lasted. Admist the ruins you find an intact marble chair, finely crafted, and embellished with what appear to be scenes of the invasion that destroyed the fortress. The art conveys a fell mood and relates to the number 3."
   },
   "tourist": {
@@ -478,7 +458,7 @@
     "displayName": "The Inventory Warehouse",
     "shortName": "inventory",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "\"This is the most crowded space you've ever been in. It's some sort of warehouse, but there are no shelves or cabinets or even really boxes, just... piles of stuff. When you appeared here you slipped and fell into a giant pile of stopped up beakers, each filled with Cloudy Potion. The glass must be pretty sturdy since none of them broke, and you slid down the pile to the ground, thankfully coming to stop before you rolled into a haphazard stack of daggers, dirks, knives, and shivs. You look around: there stacks of scrolls, spelunking equipment, weaponry, armor, and two truly enormous heaps of coins (all sorts) and food (seems to be mostly iron rations). Most of it the items you see have some utility, none of them seems especially, specifically mission-critical, and *all* of them take up space.<br/><br/>It dawns on you that this must be the Space Inventory, a dangerous realm never meant to be opened: the mythical elemental plane of Stuff. It's awe-inspiring in its own way, but most terrifying things are.<br/><br/>You idly putter about for a bit looking for anything worth taking (that's how the rogues do) but this is an inventory of inventories: all these things belong to other players somewhere in the multiverse and you aren't able to grab them. Eventually you reach an outer wall and find a sign: Inventory #11.\""
   },
   "hunger": {
@@ -486,14 +466,13 @@
     "displayName": "The Village of Hunger",
     "shortName": "Hunger",
     "hidden": true,
-    "noMediaChat": false,
+    "mediaChat": true,
     "description": "In a flash you are in a village square. Everything is muted brown and gray. A cold, dry wind blows, and pushes gentle waves of dust across the cobblestones at your feat. In the distance, beyond the village, you can see what must once have been verdant, fertile fields, dried out and dead. Above you, towering over the remains of a church, is a tower clock. The minute hand must have been lost long ago, perhaps stolen, but the hour hand remains stuck on 6. The dark, billowing clouds above you offer no rain: only a nebulous and unstated threat. Your stomach growls; it feels like ages since you've had a bite to eat."
   },
   "library": {
     "id": "library",
     "displayName": "The Library of Procedural Studies",
     "shortName": "the library",
-    "noMediaChat": true,
     "description": "A hush falls over you. Every possible space is filled with books and tomes - all the books in the entire space must be loans from here. A large sign over the circulation desk says \"NO AUDIO - TEXT ONLY! ~ Management\"<br/><br/>From here you can return to the [[hall]]."
   },
   "bar": {

--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -13,8 +13,8 @@ export interface Room {
 
   description: string
 
-  // If true, webRTC audio/video chat is blocked
-  noMediaChat?: boolean
+  // If true, webRTC audio/video chat is enabled
+  mediaChat?: boolean
 
   // Indicates whether the room should let users place post-it notes
   // As we add more pieces of one-off functionality,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -230,6 +230,7 @@ const App = () => {
         inMediaChat={state.inMediaChat}
         textOnlyMode={state.textOnlyMode}
         audioOnlyMode={state.audioOnlyMode}
+        currentUser={state.userMap[state.userId]}
       />
     )
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -221,7 +221,7 @@ const App = () => {
   // It's slightly weird we now construct this here and pass it as a prop to RoomView instead of constructing it there.
   // Shrug, the conf is in 2 days.
   let videoChatView
-  if (state.roomData && state.roomId && state.roomData[state.roomId] && !state.roomData[state.roomId].noMediaChat) {
+  if (state.roomData && state.roomId && state.roomData[state.roomId] && state.roomData[state.roomId].mediaChat) {
     videoChatView = (
       <MediaChatView
         visibleSpeakers={state.visibleSpeakers}

--- a/src/components/MediaChatButtonView.tsx
+++ b/src/components/MediaChatButtonView.tsx
@@ -11,6 +11,7 @@ interface Props {
   offscreenCount: number
   totalCount: number
   audioOnlyMode: boolean
+  canJoinVideoChat: boolean
 }
 const MediaChatButtonView = (props: Props) => {
   const {
@@ -32,6 +33,7 @@ const MediaChatButtonView = (props: Props) => {
   }
 
   const joinVideoChat = async () => {
+    if (!props.canJoinVideoChat) return
     if (currentMic || currentCamera) {
       publishMedia()
     } else {
@@ -44,6 +46,7 @@ const MediaChatButtonView = (props: Props) => {
   }
 
   const joinAudioChat = async () => {
+    if (!props.canJoinVideoChat) return
     if (currentMic) {
       publishAudio()
     } else {
@@ -91,7 +94,7 @@ const MediaChatButtonView = (props: Props) => {
     }
   }
 
-  let chatButtons
+  let chatButtons = []
   if (props.inMediaChat) {
     let leaveButtonLabel = ''
     if (publishingCamera && publishingMic) {
@@ -124,7 +127,7 @@ const MediaChatButtonView = (props: Props) => {
           Re-Enable Audio/Video
       </button>
     ]
-  } else {
+  } else if (props.canJoinVideoChat) {
     chatButtons = [
       <button key="join-video" onClick={joinVideoChat} id="join-video-chat">
         {inCall ? 'Turn on Webcam + Mic' : <s>Turn on Webcam + Mic</s>}

--- a/src/components/MediaChatButtonView.tsx
+++ b/src/components/MediaChatButtonView.tsx
@@ -94,7 +94,7 @@ const MediaChatButtonView = (props: Props) => {
     }
   }
 
-  let chatButtons = []
+  let chatButtons
   if (props.inMediaChat) {
     let leaveButtonLabel = ''
     if (publishingCamera && publishingMic) {

--- a/src/components/MediaChatView.tsx
+++ b/src/components/MediaChatView.tsx
@@ -7,6 +7,7 @@ import ParticipantChatView from './ParticipantChatView'
 import MediaChatButtonView from './MediaChatButtonView'
 import { SetTextOnlyModeAction } from '../Actions'
 import { DispatchContext } from '../App'
+import { MinimalUser } from '../../server/src/user'
 
 interface MediaProps {
   visibleSpeakers: [string, Date][]
@@ -15,6 +16,7 @@ interface MediaProps {
   inMediaChat: boolean
   textOnlyMode: boolean
   audioOnlyMode: boolean
+  currentUser: MinimalUser
 }
 
 export default function MediaChatView (props: MediaProps) {
@@ -111,6 +113,11 @@ export default function MediaChatView (props: MediaProps) {
       />
     })
 
+  // TODO: This will eventually need to check for speakers as well
+  // It's unclear to me if this logic should live here
+  // (vs inside MediaChatButtonView, or in the data model proper)
+  const canJoinVideoChat = props.currentUser.isMod
+
   // If we're showing the bar, we don't override the height; if we're hiding we force it to 0.
   // We still want it to render the audioParticipants, so that's why we still paint it.
   // TODO: this is jank
@@ -124,6 +131,7 @@ export default function MediaChatView (props: MediaProps) {
         textOnlyMode={props.textOnlyMode}
         inMediaChat={props.inMediaChat}
         totalCount={videoParticipants.length + audioParticipants.length}
+        canJoinVideoChat={canJoinVideoChat}
         offscreenCount={
           props.audioOnlyMode
             ? videoParticipants.length + audioParticipants.length

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -38,8 +38,6 @@ export default function RoomView (props: Props) {
   const dispatch = React.useContext(DispatchContext)
   const {
     prepareForMediaChat,
-    currentMic,
-    currentCamera,
     joinCall,
     unpublishMedia
   } = useMediaChatContext()

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -77,7 +77,7 @@ export default function RoomView (props: Props) {
   }
 
   React.useEffect(() => {
-    if (room && !room.noMediaChat && !props.textOnlyMode && props.hasDismissedAModal) {
+    if (room && room.mediaChat && !props.textOnlyMode && props.hasDismissedAModal) {
       // HACK ALERT: This call is necessary to properly set the state variables related to leaving video chat, since
       // our Twilio state isn't quite synchronized with our react state. We never publish if we don't want to (due to
       // passing keepCameraWhenMoving into joinCall) so we aren't publishing and unpublishing. We still need to sync.

--- a/src/room.ts
+++ b/src/room.ts
@@ -13,7 +13,7 @@ export interface Room {
   description: string;
   users?: string[];
   videoUsers?: string[];
-  noMediaChat: boolean;
+  mediaChat: boolean;
   hidden?: boolean;
   hasNoteWall: boolean;
   noteWallData: Server.NoteWallData
@@ -28,7 +28,7 @@ export function convertServerRoom (room: Server.Room): Room {
     id: room.id,
     shortName: room.shortName,
     description: room.description,
-    noMediaChat: room.noMediaChat,
+    mediaChat: room.mediaChat,
     hasNoteWall: room.hasNoteWall,
     noteWallData: room.noteWallData,
     hidden: room.hidden,


### PR DESCRIPTION
Previously, the default behavior was that all rooms had videochat, unless a `noMediaChat` property was set to true. This flips that: by default, rooms do not have videochat, and they need `"mediaChat": true` set to enable it.

In 2022, the current design plan is to only enable videochat for mods and speakers in the speaker breakout rooms. This design will better facilitate that.

Additionally, this makes it so that, while all users can "join" videochat (in the sense that their client will receive others AV streams), only admins can actively broadcast their own audio/video. We will eventually expand this to include speakers, but we do not yet have an in-engine way to determine which users are speakers.