### PR TITLE
Store Rainway API key in ENV

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,4 @@ FIREBASE_PROJECT_ID=firebase_project_id
 FIREBASE_STORAGE_BUCKET=firebase_storage_bucket
 FIREBASE_MESSAGING_SENDER_ID=firebase_messaging_sender_id
 FIREBASE_APP_ID=firebase_app_id
+RAINWAY_API_KEY=rainway_api_key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,6 +23,7 @@ jobs:
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
           FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.FIREBASE_MESSAGING_SENDER_ID }}
           FIREBASE_APP_ID: ${{ secrets.FIREBASE_APP_ID }}
+          RAINWAY_API_KEY: ${{ secrets.RAINWAY_API_KEY }}
 
       - name: Deploy Frontend
         uses: peaceiris/actions-gh-pages@v3

--- a/src/components/Rainway/RainwayStreamView.tsx
+++ b/src/components/Rainway/RainwayStreamView.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react'
 import { RainwayChannelMode, RainwayPeer, RainwayPeerState, RainwayError, RainwayRuntime, RainwayStreamAnnouncement } from '@rainway/web'
 import { Widget } from './Widget'
+import Config from '../../config'
 
 interface DemoPeer {
   peerId: bigint;
@@ -12,8 +13,6 @@ interface DemoPeer {
 export default function RainwayStreamView (props: {}) {
   // TODO: The sample sets this via localStorage.
   // We probably want to wire it up to our infra
-  const [apiKey, setApiKey] = useState('api-key')
-
   const [connectingRuntime, setConnectingRuntime] = useState(false)
   const [runtime, setRuntime] = useState<RainwayRuntime | undefined>()
   const [peers, setPeers] = useState<DemoPeer[]>([])
@@ -52,7 +51,7 @@ export default function RainwayStreamView (props: {}) {
       setConnectingRuntime(true)
       try {
         rt = await RainwayRuntime.initialize({
-          apiKey: apiKey,
+          apiKey: Config.RAINWAY_API_KEY,
           externalId: 'web-demo-react',
           onRuntimeConnectionLost: (rt, error) => {
             // When the connection is fatally lost, drop all peers.
@@ -126,34 +125,23 @@ export default function RainwayStreamView (props: {}) {
   return (
     <div>
       <div className="m-b-8 flex">
-        <h2>
-          <label htmlFor="apiKey">API key</label>
-        </h2>
+        <br/>
         {runtime ? (
-          <div className="m-l-8 badge ok">Connected</div>
+          <div className="m-l-8 badge ok">Connected to Rainway</div>
         ) : connectingRuntime ? (
           <div className="m-l-8 badge">Connecting…</div>
         ) : (
-          <div className="m-l-8 badge">Disconnected</div>
+          <div>
+            <button
+              className="m-l-16"
+              disabled={runtime !== undefined || connectingRuntime}
+              onClick={connectToRainway}
+            >
+                    Connect to Rainway
+            </button>
+          </div>
         )}
       </div>
-      <input
-        id="apiKey"
-        type="text"
-        spellCheck={false}
-        size={36}
-        value={apiKey}
-        disabled={runtime !== undefined || connectingRuntime}
-        onChange={(e) => setApiKey(e.target.value)}
-        placeholder="pk_live_xxxxxxxxxxxxxxxxxxxxxxxx"
-      />
-      <button
-        className="m-l-16"
-        disabled={runtime !== undefined || connectingRuntime}
-        onClick={connectToRainway}
-      >
-        Connect to Rainway
-      </button>
       {peers.map((p) => (
         <Widget
           key={p.peerId.toString()}

--- a/src/config.ts
+++ b/src/config.ts
@@ -7,5 +7,6 @@ export default {
     storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
     messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
     appId: process.env.FIREBASE_APP_ID
-  }
+  },
+  RAINWAY_API_KEY: process.env.RAINWAY_API_KEY
 }


### PR DESCRIPTION
This removes the "enter API key" field when testing out Rainway.

There's a `rainway-2` branch that has deeper integration for sending Rainway peer IDs over the wire, but because that involves messing with the rest of the app's infrastructure (a HTTP endpoint, a new SignalR message, a new Action, etc) I'm holding off on merging that in until we know we want this, since right now this is a clear revert.