### PR TITLE
Show older messages from previous rooms behind a toggelable button

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -89,15 +89,20 @@ export default function ChatView (props: Props) {
           }
         }
 
+        const shouldShowInterstitial = m.type === MessageType.MovedRoom
         const id = `message-${idx}`
+
         return (
-          <MessageView
-            message={m}
-            key={id}
-            id={id}
-            hideTimestamp={hideTimestamp}
-            msgIndex={idx}
-          />
+          <>
+            {shouldShowInterstitial ? <hr key={id + '-interstitial'}/> : null}
+            <MessageView
+              message={m}
+              key={id}
+              id={id}
+              hideTimestamp={hideTimestamp}
+              msgIndex={idx}
+            />
+          </>
         )
       })}
     </div>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import { findLastIndex } from 'lodash'
 
 import MessageView from './MessageView'
 import { Message, MessageType, ConnectedMessage, DisconnectedMessage, EnteredMessage, LeftMessage } from '../message'
@@ -68,18 +69,6 @@ export default function ChatView (props: Props) {
       if (props.captionsEnabled) return true
       return msg.type !== MessageType.Caption
     })
-
-  function findLastIndex<T> (array: T[], evaluator: (T) => Boolean) {
-    let targetIndex = -1
-
-    array.forEach((item, index) => {
-      if (evaluator(item)) {
-        targetIndex = index
-      }
-    })
-
-    return targetIndex
-  }
 
   const lastIndexOfMovedMessage = findLastIndex(
     messages,

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -48,6 +48,8 @@ export default function ChatView (props: Props) {
     }
   })
 
+  const [shouldShowOldMessages, setShouldShowOldMessages] = React.useState(false)
+
   // This message filtering logic is kinda ugly and hard to read
   function shouldRemoveMessage (m: Message) {
     return isMovementMessage(m) &&
@@ -67,44 +69,72 @@ export default function ChatView (props: Props) {
       return msg.type !== MessageType.Caption
     })
 
+  function findLastIndex<T> (array: T[], evaluator: (T) => Boolean) {
+    let targetIndex = -1
+
+    array.forEach((item, index) => {
+      if (evaluator(item)) {
+        targetIndex = index
+      }
+    })
+
+    return targetIndex
+  }
+
+  const lastIndexOfMovedMessage = findLastIndex(
+    messages,
+    message => message.type === MessageType.MovedRoom
+  )
+  const currentRoomMessages = messages.slice(lastIndexOfMovedMessage)
+
+  const shownMessages = shouldShowOldMessages ? messages : currentRoomMessages
+
   return (
-    <div id="messages" onScroll={handleScroll}>
-      {messages.slice(-150).map((m, idx) => {
-        let hideTimestamp = false
-        const previousMessage = props.messages[idx - 1]
-        if (previousMessage) {
-          // TODO: Give all messages a userId for this to be meaningful
-          if (
-            (previousMessage as any).userId &&
-            (m as any).userId &&
-            (previousMessage as any).userId === (m as any).userId
-          ) {
-            const diff =
-              new Date(m.timestamp).getTime() -
-              new Date(previousMessage.timestamp).getTime()
-            // This is a bad way to calculate '3 minutes' and I should feel bad -em
-            if (diff < 1000 * 60 * 3) {
-              hideTimestamp = true
+    <>
+      <button
+        className="link-styled-button"
+        onClick={() => setShouldShowOldMessages(!shouldShowOldMessages)}
+      >
+        {shouldShowOldMessages ? 'Hide' : 'Show'} Older Messages
+      </button>
+      <div id="messages" onScroll={handleScroll}>
+        {shownMessages.slice(-150).map((m, idx) => {
+          let hideTimestamp = false
+          const previousMessage = props.messages[idx - 1]
+          if (previousMessage) {
+            // TODO: Give all messages a userId for this to be meaningful
+            if (
+              (previousMessage as any).userId &&
+          (m as any).userId &&
+          (previousMessage as any).userId === (m as any).userId
+            ) {
+              const diff =
+            new Date(m.timestamp).getTime() -
+            new Date(previousMessage.timestamp).getTime()
+              // This is a bad way to calculate '3 minutes' and I should feel bad -em
+              if (diff < 1000 * 60 * 3) {
+                hideTimestamp = true
+              }
             }
           }
-        }
 
-        const shouldShowInterstitial = m.type === MessageType.MovedRoom
-        const id = `message-${idx}`
+          const shouldShowInterstitial = m.type === MessageType.MovedRoom
+          const id = `message-${idx}`
 
-        return (
-          <>
-            {shouldShowInterstitial ? <hr key={id + '-interstitial'}/> : null}
-            <MessageView
-              message={m}
-              key={id}
-              id={id}
-              hideTimestamp={hideTimestamp}
-              msgIndex={idx}
-            />
-          </>
-        )
-      })}
-    </div>
+          return (
+            <>
+              {shouldShowInterstitial ? <hr key={id + '-interstitial'}/> : null}
+              <MessageView
+                message={m}
+                key={id}
+                id={id}
+                hideTimestamp={hideTimestamp}
+                msgIndex={idx}
+              />
+            </>
+          )
+        })}
+      </div>
+    </>
   )
 }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -49,7 +49,7 @@ export default function ChatView (props: Props) {
     }
   })
 
-  const [shouldShowOldMessages, setShouldShowOldMessages] = React.useState(false)
+  const [shouldShowOlderMessages, setShouldShowOlderMessages] = React.useState(false)
 
   // This message filtering logic is kinda ugly and hard to read
   function shouldRemoveMessage (m: Message) {
@@ -75,16 +75,15 @@ export default function ChatView (props: Props) {
     message => message.type === MessageType.MovedRoom
   )
   const currentRoomMessages = messages.slice(lastIndexOfMovedMessage)
-
-  const shownMessages = shouldShowOldMessages ? messages : currentRoomMessages
+  const shownMessages = shouldShowOlderMessages ? messages : currentRoomMessages
 
   return (
     <>
       <button
         className="link-styled-button"
-        onClick={() => setShouldShowOldMessages(!shouldShowOldMessages)}
+        onClick={() => setShouldShowOlderMessages(!shouldShowOlderMessages)}
       >
-        {shouldShowOldMessages ? 'Hide' : 'Show'} Older Messages
+        {shouldShowOlderMessages ? 'Hide' : 'Show'} Older Messages
       </button>
       <div id="messages" onScroll={handleScroll}>
         {shownMessages.slice(-150).map((m, idx) => {


### PR DESCRIPTION
This is a start at an implementation for #155.

- This PR adds an `hr` into the chat log before every `MovedRoom` message
- This PR adds a button-link to the top of the chat panel to toggle the showing/hiding of messages from rooms older than the current one

<img width="1134" alt="Screen Shot 2022-07-26 at 10 11 54 PM" src="https://user-images.githubusercontent.com/9389625/181167952-f0f819c9-07be-478f-ac29-861f0d6c11ef.png">

<img width="1174" alt="Screen Shot 2022-07-26 at 10 11 49 PM" src="https://user-images.githubusercontent.com/9389625/181167934-b08d26a0-1fb4-4bdf-8ae7-c527993da025.png">

Design-wise, I'm not so sure about the positioning of the "Show/Hide older messages" link. I think the "Hide older messages" version is particularly confusing as implemented here. Changing the wording might solve this issue. Something like "Hide messages from previous rooms"? But then the link starts getting pretty long!

The other idea I had design-wise was to insert the link into the chat window by the `hr` for the most recently entered room. This feels like a pretty drastic vibe change though, so didn't really want to pursue that on my own. Additionally, if a user has scrolled pretty far up in past messages or if they have received a lot of current messages they'd lose the reference to the "show older messages" button. But maybe this is desirable?

Implementation-wise, I have added a few comments. I'm not sure if my approaches are inline with the project's architecture or not!
