### PR TITLE
Add Custom Emoji support to the Chat 

### DIFF
--- a/src/components/InputView.tsx
+++ b/src/components/InputView.tsx
@@ -4,6 +4,7 @@ import { DispatchContext, UserMapContext } from '../App'
 
 import '../../style/input.css'
 import { PublicUser } from '../../server/src/user'
+import { emojiMentionsData } from '../emoji'
 const emojifier = require('node-emoji')
 
 export default function InputView (props: {
@@ -80,6 +81,18 @@ export default function InputView (props: {
           className="mentions__mentions"
           markup="@@[[__display__]]``__id__``@@"
           data={usersInRoom}
+          renderSuggestion={(suggestion, search, highlightedDisplay) => {
+            return (
+              <div>{highlightedDisplay}</div>
+            )
+          }}
+        />
+        <Mention
+          trigger=":"
+          className="mentions__custom_emoji"
+          markup=":__id__:"
+          data={emojiMentionsData}
+          displayTransform={(id, display) => `:${id}:`}
           renderSuggestion={(suggestion, search, highlightedDisplay) => {
             return (
               <div>{highlightedDisplay}</div>

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -30,6 +30,7 @@ import NameView from './NameView'
 import { DispatchContext, UserMapContext, RoomDataContext } from '../App'
 import { deleteMessage, fetchProfile, moveToRoom } from '../networking'
 import { join, split } from 'lodash'
+import { renderCustomEmojiString } from '../emoji'
 
 const formatter = new Intl.DateTimeFormat('en', { hour: 'numeric', minute: 'numeric' })
 
@@ -202,9 +203,12 @@ const ChatMessageView = (props: ChatMessage & { id: string }) => {
         return <>{acc} {userIdOrDisplay}</>
       }
     } else {
-      return <>{acc} {fragment}</>
+      const customEmojified = renderCustomEmojiString(fragment)
+
+      return <>{acc} {customEmojified}</>
     }
   }, <></>)
+
   return (
     <div className="message">
       <NameView userId={props.userId} id={props.id} />: <DeletableMessageView messageId={props.messageId}>{joinedMessage}</DeletableMessageView>

--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -179,6 +179,11 @@ const SameView = (props: SameRoomMessage & { id: string }) => (
 
 const parseUserIdOrDisplay = (messageFragment): string => {
   const userId = messageFragment.match(/``(.*?)``/)
+
+  if (!userId) {
+    return 'Malformed Mention'
+  }
+
   if (userId.length === 2) {
     return userId[1]
   }

--- a/src/emoji/customEmojiMap.json
+++ b/src/emoji/customEmojiMap.json
@@ -1,0 +1,3 @@
+{
+  "spelunky_pug": "https://static.wikia.nocookie.net/spelunky/images/a/a4/Monty_Link_S2.png"
+}

--- a/src/emoji/index.tsx
+++ b/src/emoji/index.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+import customEmojiMap from './customEmojiMap.json'
+
+export function renderCustomEmojiString (string: string) {
+  const stringParts = string.split(/(:.*?:)/)
+  const emojiComponent = stringParts.reduce<JSX.Element>((newComponent, stringPart) => {
+    if (stringPart.startsWith(':') && stringPart.endsWith(':')) {
+      const emojiIdRegex = /:(.*):/
+      const [_, emojiId] = emojiIdRegex.exec(stringPart)
+
+      if (customEmojiMap[emojiId]) {
+        return <>{newComponent} {<img className="inline-custom-emoji" alt={':' + emojiId + ':'} src={customEmojiMap[emojiId]}/>}</>
+      }
+
+      return <>{newComponent} {':' + emojiId + ':'}</>
+    }
+
+    return <>{newComponent} {stringPart}</>
+  }, <></>)
+
+  return emojiComponent
+}
+
+export const emojiMentionsData = Object.keys(customEmojiMap).map(key => {
+  return {
+    id: key
+  }
+})

--- a/style/chat.css
+++ b/style/chat.css
@@ -32,3 +32,9 @@
 .movement-message {
   opacity: 0.5
 }
+
+.inline-custom-emoji {
+  height: 1.3rem;
+  position: relative;
+  bottom: -0.2rem;
+}


### PR DESCRIPTION
This PR is for Issue #66 and implements custom emoji in the chat interface.

It uses the `react-mentions` library introduced in #615 for autocompletion of custom emoji. Additionally, it piggy backs on the new rendering logic necessary to render users inside of ChatMessageViews.

## What it does
- When a user types `:` in the chat input, they'll be shown a list of all implemented custom emoji
- The user can filter these by typing 
- When they hit enter the `:custom_emoji:` key is added to their chat input. It remains in plaintext this way.
- When they send their message, any text in the format `:words:` is checked to see if it matches a custom emoji. This includes copy pasted text.
- If it does, it is replaced with an inline image with the `src` as specified in the `customEmojiMap.json` file.
- Copying emoji images _should_ copy them in the `:custom_emoji:` format due to their alt text.

<img width="1051" alt="rl-celeb-many-custom-emoji" src="https://user-images.githubusercontent.com/9389625/188788951-6987d9e7-1922-41aa-b4ad-bd17c00cdcb7.png">

## Questions
1. Is it now confusing to see `:star:` turn into ⭐️ while you're tying, but `:spelunky_pug:` remains as text until you send it?

<img width="1042" alt="rl-celeb-custom-emoji-vs-standard" src="https://user-images.githubusercontent.com/9389625/188788586-e246baaa-1589-45f8-a96f-91496c2eac9a.png">

2. Where should we upload custom emoji images for our use?
3. What custom emoji do we want?