### PR TITLE
Remove max word length

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,2 +1,1 @@
 export const MESSAGE_MAX_LENGTH = 631
-export const MESSAGE_MAX_WORD_LENGTH = 60

--- a/server/src/endpoints/sendChatMessage.ts
+++ b/server/src/endpoints/sendChatMessage.ts
@@ -5,7 +5,7 @@ import { whisper } from '../whisper'
 import { shout } from '../shout'
 import { look } from '../look'
 import { getUserIdForUsername, User } from '../user'
-import { MESSAGE_MAX_LENGTH, MESSAGE_MAX_WORD_LENGTH } from '../config'
+import { MESSAGE_MAX_LENGTH } from '../config'
 import { dance } from '../dance'
 import { interact } from '../interact'
 
@@ -23,13 +23,6 @@ const sendChatMessage: AuthenticatedEndpointFunction = async (user: User, inputs
       httpResponse: {
         status: 400,
         body: 'Message length too long!'
-      }
-    }
-  } else if (message.split(' ').find((e: string) => e.length > MESSAGE_MAX_WORD_LENGTH)) {
-    return {
-      httpResponse: {
-        status: 400,
-        body: 'Message contains a word that is too long!'
       }
     }
   }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -33,7 +33,7 @@ import { PublicUser, MinimalUser, User } from '../server/src/user'
 import { v4 as uuidv4 } from 'uuid'
 import { Modal } from './modals'
 import { matchingSlashCommand, SlashCommandType } from './SlashCommands'
-import { MESSAGE_MAX_LENGTH, MESSAGE_MAX_WORD_LENGTH } from '../server/src/config'
+import { MESSAGE_MAX_LENGTH } from '../server/src/config'
 import { ServerSettings, DEFAULT_SERVER_SETTINGS } from '../server/src/types'
 import * as Storage from './storage'
 import firebase from 'firebase/app'
@@ -384,8 +384,6 @@ export default (oldState: State, action: Action): State => {
 
     if (trimmedMessage.length > MESSAGE_MAX_LENGTH) {
       addMessage(state, createErrorMessage('Your message is too long! Please try to keep it under ~600 characters!'))
-    } else if (trimmedMessage.split(' ').find((s) => s.length > MESSAGE_MAX_WORD_LENGTH)) {
-      addMessage(state, createErrorMessage('Your message has a word that is too long! Please keep it under 60 characters!'))
     } else if (beginsWithSlash && matching === undefined) {
       const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
       addMessage(state, createErrorMessage(`Your command ${commandStr ? commandStr[1] : action.value} is not a registered slash command!`))

--- a/style/chat.css
+++ b/style/chat.css
@@ -26,7 +26,7 @@
 }
 
 .message {
-  overflow-wrap: break-word;
+  overflow-wrap: anywhere;
 }
 
 .movement-message {


### PR DESCRIPTION
The main concern with max word length was screen stretching, this changes the word break behavior so we can get rid of the word limit. The main reason we'd want to change that was people couldn't post links in chat.

Pictures of new line break behavior (will break at the overflow if the text is too long, else will attempt to break on whitespace):

![Screenshot from 2022-09-08 16-26-47](https://user-images.githubusercontent.com/1434086/189243078-8bf2c128-d017-48ff-a2b2-78acc05e9f07.png)
![Screenshot from 2022-09-08 16-26-33](https://user-images.githubusercontent.com/1434086/189243081-426276e8-4852-462a-aa30-5694b3bf84b8.png)
