### PR TITLE
Attempt to fix presence when moving to a new room

### DIFF
--- a/server/src/moveToRoom.ts
+++ b/server/src/moveToRoom.ts
@@ -69,6 +69,13 @@ export async function moveToRoom (
     }
   }
 
+  // We send presence data as a SignalR message as part of this HTTP call
+  // HOWEVER! Our client isn't smart enough to merge things correctly
+  // if it gets that presence message BEFORE the HTTP request returns, which is likely
+  // There are potentially better ways to solve this, but making sure the HTTP response
+  // contains presence data is ~fine~
+  to.users = await DB.roomOccupants(to.id)
+
   const awardedBadges = awardBadges(user, to.id)
 
   const response: RoomResponse = {

--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -1,6 +1,5 @@
 import json from './data/roomData.json'
 import DB from '../redis'
-import { minimizeUser } from '../user'
 
 export const staticRoomData: {[name: string]: Room} = json
 
@@ -39,6 +38,9 @@ export interface Room {
   chatGuid?: string
 
   riddles?: string[]
+
+  // Array of users currently in this room
+  users?: string[]
 }
 
 export interface NoteWallData {


### PR DESCRIPTION
What we're experiencing is players who move to a new room won't see a presence bar ("In here are X, Y, and Z"), but if you refresh the page it's there.

There appears to be a race condition. Not 100% certain this fixes it, but I'm seeing discrepancies between code manually pushed to a server versus going through our deploy pipeline, so pushing this to test.