### PR TITLE
Fix polymorph being dropped from name view

### DIFF
--- a/src/components/NameView.tsx
+++ b/src/components/NameView.tsx
@@ -151,6 +151,7 @@ export default function NameView (props: Props) {
   const nameEl = (
     <strong className={isMod ? 'mod' : ''}>
       {isMod ? '[Mod] ' : ''}
+      {(!useSimpleNames && user && user.polymorph) || ''}
       {username || 'unknown'}
       {useSimpleNames ? '' : badges}
     </strong>


### PR DESCRIPTION
The line to include the polymorph emoji just got dropped during badge iteration, put it back.