### PR TITLE
Fix Immer crash on sorting room notes

### DIFF
--- a/src/components/NoteWallView.tsx
+++ b/src/components/NoteWallView.tsx
@@ -7,6 +7,7 @@ import { NoteView } from './NoteView'
 import '../../style/noteWall.css'
 import { NoteWallData } from '../../server/src/rooms'
 import { PublicUser } from '../../server/src/user'
+import { sortBy } from 'lodash'
 
 // TODO: insanely silly to hardcode these here, since they can easily fall out of sync
 // If you're reading this, these are the specific room ids for Roguelike Celebration 2021
@@ -48,10 +49,9 @@ export function NoteWallView (props: {notes: RoomNote[], noteWallData?: NoteWall
     }
   }
 
-  const sortedNotes = (props.notes || []).sort((a, b) => {
-    const aLikes = a.likes ? a.likes.length : 0
-    const bLikes = b.likes ? b.likes.length : 0
-    return bLikes - aLikes
+  const sortedNotes = sortBy(props.notes || [], (note) => {
+    // Lodash sortBy is always ascending, so we negative it out to get descending
+    return note.likes ? -note.likes.length : 0
   })
 
   const noteViews = sortedNotes.map(n => <NoteView key={n.id} note={n} />)


### PR DESCRIPTION
This appears to have been crashing when using JS Array.sort on an Immer'd object (validly, since Array.sort mutates! Immer caught us doing a bad thing!)

Switching to lodash fixes it, and I'm happy with this, but I'm curious if there's a more Immer-y solve.