### PR TITLE
Return new user properties on updateProfile endpoint

### DIFF
--- a/server/src/endpoints/updateProfile.ts
+++ b/server/src/endpoints/updateProfile.ts
@@ -32,7 +32,7 @@ const updateProfile: EndpointFunction = async (inputs: any, log: LogFn) => {
       }],
       httpResponse: {
         status: 200,
-        body: { valid: true }
+        body: { valid: true, user: minimalUser }
       }
     }
   } catch (e) {


### PR DESCRIPTION
This PR attempts to address #540 based on the information I found while fixing #664.

The issue seems to be:
- When you submit "Edit Profile", the updateProfile server endpoint is called
- On success, the [client dispatches a context update](https://github.com/Roguelike-Celebration/azure-mud/blob/main/src/networking.ts#L123) with the new user profile
- Currently, the [updateProfile endpoint does not seem to return a user](https://github.com/Roguelike-Celebration/azure-mud/blob/main/server/src/endpoints/updateProfile.ts#L33-L36) property though

This PR assumes that:
- The correct fix is to actually return a user from the updateProfile endpoint, there might be a good reason I'm not aware of we're not already returning the new user object.
- The minimalUser in the updateProfile endpoint is the appropriate form of this data to return to the user's client.
- I am doing this correctly as I do not have a local server environment set up and am not familiar with this endpoint syntax!