### PR TITLE
Give chat name/msg context menus different keys

### DIFF
--- a/src/components/MessageView.tsx
+++ b/src/components/MessageView.tsx
@@ -77,14 +77,15 @@ export default memo(function MessageView (props: { message: Message, hideTimesta
 })
 
 const handleDeleteMessage = (e, data) => {
-  const doDelete = confirm(`Are you sure you would like to delete the message '${data.message}'?`)
+  const doDelete = confirm(`Are you sure you would like to delete the message '${data.messageText}'?`)
   if (doDelete) {
     deleteMessage(data.messageId)
   }
 }
 
 type DeletableMessageViewProps = {
-  messageId: string
+  messageId: string,
+  messageText: string
 }
 
 const linkDecorator = (href, text, key) => (
@@ -100,15 +101,17 @@ const DeletableMessageView: FunctionComponent<DeletableMessageViewProps> = (prop
   if (!playerIsMod) {
     return <Linkify componentDecorator={linkDecorator}>{props.children}</Linkify>
   } else {
+    const key: string = `${props.messageId}-name`
+
     return (
       <Linkify componentDecorator={linkDecorator}>
         <span className="deleteMenu">
-          <ContextMenuTrigger id={props.messageId} mouseButton={2} renderTag="span">
+          <ContextMenuTrigger id={key} mouseButton={2} renderTag="span">
             {props.children}
           </ContextMenuTrigger>
-          <ContextMenu id={props.messageId}>
+          <ContextMenu id={key}>
             <MenuItem
-              data={{ messageId: props.messageId, message: props.children }}
+              data={{ messageId: props.messageId, message: props.children, messageText: props.messageText }}
               onClick={handleDeleteMessage}
             >
               { 'Delete Message?' }
@@ -216,14 +219,14 @@ const ChatMessageView = (props: ChatMessage) => {
 
   return (
     <div className="message">
-      <NameView userId={props.userId} id={props.id} />: <DeletableMessageView messageId={props.id}>{joinedMessage}</DeletableMessageView>
+      <NameView userId={props.userId} id={props.id} />: <DeletableMessageView messageId={props.id} messageText={props.message}>{joinedMessage}</DeletableMessageView>
     </div>
   )
 }
 
 const CaptionView = (props: CaptionMessage) => (
   <div className="message">
-    <NameView userId={props.userId} id={props.id} /> (spoken): <DeletableMessageView messageId={props.id}>{props.message}</DeletableMessageView>
+    <NameView userId={props.userId} id={props.id} /> (spoken): <DeletableMessageView messageId={props.id} messageText={props.message}>{props.message}</DeletableMessageView>
   </div>
 )
 
@@ -277,7 +280,7 @@ const ModMessageView = (props: ModMessage) => {
 const ShoutView = (props: ShoutMessage) => {
   return (
     <div className="message">
-      <NameView userId={props.userId} id={props.id} /> shouts: <DeletableMessageView messageId={props.id}>{props.message}</DeletableMessageView>
+      <NameView userId={props.userId} id={props.id} /> shouts: <DeletableMessageView messageId={props.id} messageText={props.message}>{props.message}</DeletableMessageView>
     </div>
   )
 }
@@ -285,7 +288,7 @@ const ShoutView = (props: ShoutMessage) => {
 const EmoteView = (props: EmoteMessage) => {
   return (
     <div className="message">
-      <em><NameView userId={props.userId} id={props.id} /> <DeletableMessageView messageId={props.id}>{props.message}</DeletableMessageView></em>
+      <em><NameView userId={props.userId} id={props.id} /> <DeletableMessageView messageId={props.id} messageText={props.message}>{props.message}</DeletableMessageView></em>
     </div>
   )
 }


### PR DESCRIPTION
The chat context menus weren't working because the name context menu and the message context menu were being given the same ContextMenuTrigger ID. I fixed it by adding a suffix to the name triggers. Also I added a prop so the delete confirmation will include the text of the message rather than "Are you sure you want to delete [object Object]?"