### PR TITLE
Add z-index to context menu

### DIFF
--- a/style/nameView.css
+++ b/style/nameView.css
@@ -15,6 +15,7 @@ nav.react-contextmenu {
   background-color: var(--alternate-background);
   border: 1px solid var(--main-font);
   cursor: pointer;
+  z-index: 1;
 }
 
 @media only screen and (max-device-width: 500px) {


### PR DESCRIPTION
Context menu was appearing underneath input field; giving it a z-index of 1 popped it to the top.