### PR TITLE
Guard Against `undefined` Messages

### DIFF
--- a/src/message/utils.ts
+++ b/src/message/utils.ts
@@ -40,9 +40,9 @@ const deletableMessageTypes = [
 ]
 
 export const isDeletableMessage = (
-  message: Message
+  message: Message | undefined
 ): message is AnyDeletableMessage =>
-  deletableMessageTypes.includes(message.type)
+  message !== undefined && deletableMessageTypes.includes(message.type)
 
 type AnyMovementMessage =
   | ConnectedMessage


### PR DESCRIPTION
Noticed this while messing around … the message passed to `isDeletableMessage` _could_ be `undefined` in which case `message.type` throws an error. This prevents that from happening by checking that the message object is not undefined first