### PR TITLE
Return entire new profile instead of minimalUser

### DIFF
--- a/server/src/endpoints/updateProfile.ts
+++ b/server/src/endpoints/updateProfile.ts
@@ -32,7 +32,7 @@ const updateProfile: EndpointFunction = async (inputs: any, log: LogFn) => {
       }],
       httpResponse: {
         status: 200,
-        body: { valid: true, user: minimalUser }
+        body: { valid: true, user: profile }
       }
     }
   } catch (e) {


### PR DESCRIPTION
My previous PR #683 returned the minimalUser object on the updateProfile update. However, this does not include all of the information a user would update, like pronouns and bio. 

This PR has the endpoint return the entire new profile object instead.