### PR TITLE
Send /mod messages to discord

### DIFF
--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -40,6 +40,8 @@ import firebase from 'firebase/app'
 import Config from './config'
 import { Badge } from '../server/src/badges'
 import produce from 'immer'
+import { sendToDiscord } from './sendToDiscord'
+
 export interface State {
   firebaseApp: firebase.app.App;
   authenticated: boolean;
@@ -252,6 +254,7 @@ export default produce((draft: State, action: Action) => {
   }
 
   if (action.type === ActionType.ModMessage) {
+    sendToDiscord({ username: draft.userMap[action.value.name].username, message: action.value.message })
     addMessage(
       draft,
       createModMessage(

--- a/src/sendToDiscord.ts
+++ b/src/sendToDiscord.ts
@@ -1,0 +1,11 @@
+export function sendToDiscord ({ message, username }) {
+  const msg = {
+    content: `${username}: ${message}`
+  }
+  const url = process.env.DISCORD_URL
+  fetch(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(msg)
+  })
+}


### PR DESCRIPTION
I tested this on my own server with a hardcoded URL, so double-check I didn't typo the environment variable name. 

It did send every message _twice_, which isn't ideal. For some reason the reducer is running twice (and I'm not familiar enough with reducers to sort out why). Maybe it's because I myself am a mod? In any case I think double-messages are better than none, and if it turns out to be too spammy, we can always just disable the webhook.