### PR TITLE
Update schedule for 2022

### DIFF
--- a/src/components/HappeningNowView.tsx
+++ b/src/components/HappeningNowView.tsx
@@ -4,7 +4,7 @@ import { HideModalAction } from '../Actions'
 import { DispatchContext } from '../App'
 import { moveToRoom } from '../networking'
 import { Room } from '../room'
-import { ScheduleEntries } from './ScheduleView'
+import { nowDate, ScheduleEntries } from './ScheduleView'
 
 // Apparently reverse() does an actual reversal! WELL. All right then, Javascript.
 const ReversedScheduleEntries = [...ScheduleEntries].reverse()
@@ -12,9 +12,7 @@ const ReversedScheduleEntries = [...ScheduleEntries].reverse()
 export default function HappeningNowView (props: { roomData: { [roomId: string]: Room }, entries: HappeningNowEntry[] }) {
   const dispatch = useContext(DispatchContext)
 
-  // To test this functionality, just set it at some appropriate date in the conference time
-  // const now = new Date(`2021-10-16T10:35:00.000-07:00`)
-  const now = new Date()
+  const now = nowDate()
   const currentlyScheduledIdx = ReversedScheduleEntries.findIndex((entry) => entry.time < now)
   const currentlyScheduled = ReversedScheduleEntries[currentlyScheduledIdx]
 

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -1,6 +1,15 @@
+import { now } from 'lodash'
 import React from 'react'
 
 const SOCIAL_TIME = 'Social Time'
+
+// Generate the current date for both the schedule and "happening now"
+// If you want to test functionality, stub in a fake date here
+// (this only exists to allow that testing functionality)
+export function nowDate () {
+  // After 2022 day 1, before day 2: '2022-10-22T22:00:00.000-07:00'
+  return new Date()
+}
 
 export interface ScheduleEntry {
   time: Date,
@@ -87,7 +96,7 @@ export default function ScheduleView () {
   const formatter = new Intl.DateTimeFormat('en', { hour: 'numeric', minute: 'numeric' })
   const userTimeZone = formatter.resolvedOptions().timeZone
 
-  const today = new Date()
+  const today = nowDate()
 
   // If it's before the event or day 1, show day 1. Otherwise show day 2
   // TODO: This logic will need adjusting for a preview event

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -128,7 +128,7 @@ export default function ScheduleView () {
 
   return (
     <div id='Schedule'>
-      <h1>Schedule</h1>
+      <h1>Schedule: Day {day}</h1>
       <p>Times below should be in your local time zone. We believe your time zone is {userTimeZone}.</p>
       <table>
         <tbody>

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -6,25 +6,26 @@ export interface ScheduleEntry {
   time: Date,
   text: string,
   roomIds: string[]
-  breakoutRoomId?: string
+  breakoutRoomId?: string,
+  day: number
 }
 
-function ScheduleEntry (time: string, day: number, text: string, roomIds?: string[], breakoutRoomId?: string) {
-  const dayPreview = (time) => new Date(`2022-09-11T${time}:00.000-07:00`)
-  const dayOneDate = (time) => new Date(`2022-10-22T${time}:00.000-07:00`)
-  const dayTwoDate = (time) => new Date(`2022-10-23T${time}:00.000-07:00`)
+const dayPreview = (time) => new Date(`2022-09-11T${time}:00.000-07:00`)
+const dayOneDate = (time) => new Date(`2022-10-22T${time}:00.000-07:00`)
+const dayTwoDate = (time) => new Date(`2022-10-23T${time}:00.000-07:00`)
 
+function ScheduleEntry (time: string, day: number, text: string, roomIds?: string[], breakoutRoomId?: string) {
   if (day === 0) {
     return {
-      time: dayPreview(time), text: text, roomIds: roomIds, breakoutRoomId: breakoutRoomId
+      time: dayPreview(time), text: text, roomIds: roomIds, breakoutRoomId: breakoutRoomId, day
     }
   } else if (day === 1) {
     return {
-      time: dayOneDate(time), text: text, roomIds: roomIds, breakoutRoomId: breakoutRoomId
+      time: dayOneDate(time), text: text, roomIds: roomIds, breakoutRoomId: breakoutRoomId, day
     }
   } else if (day === 2) {
     return {
-      time: dayTwoDate(time), text: text, roomIds: roomIds, breakoutRoomId: breakoutRoomId
+      time: dayTwoDate(time), text: text, roomIds: roomIds, breakoutRoomId: breakoutRoomId, day
     }
   } else {
     console.error('Your static data is messed up, somehow.')
@@ -86,7 +87,22 @@ export default function ScheduleView () {
   const formatter = new Intl.DateTimeFormat('en', { hour: 'numeric', minute: 'numeric' })
   const userTimeZone = formatter.resolvedOptions().timeZone
 
-  const rows = ScheduleEntries.flatMap(r => {
+  const today = new Date()
+
+  // If it's before the event or day 1, show day 1. Otherwise show day 2
+  // TODO: This logic will need adjusting for a preview event
+
+  const endOfDayOne = ScheduleEntries.slice().reverse().find(e => e.day === 1).time
+  endOfDayOne.setTime(endOfDayOne.getTime() + (1 * 60 * 60 * 1000)) // Add 1 hour after the last event
+
+  let day = 2
+  // TODO: This will be busted, time zones
+  if (today <= endOfDayOne) {
+    day = 1
+  }
+  const entries = ScheduleEntries.filter(e => e.day === day)
+
+  const rows = entries.flatMap(r => {
     if (r.text === SOCIAL_TIME) {
       return [(<tr key={formatter.format(r.time) + 'hr1'}><th className='break' colSpan={2}><hr /></th></tr>),
         (<tr key={formatter.format(r.time) + 'text'}><td className='time'>{formatter.format(r.time)}</td><td className='segment'>Social Time</td></tr>),

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -11,8 +11,8 @@ export interface ScheduleEntry {
 
 function ScheduleEntry (time: string, day: number, text: string, roomIds?: string[], breakoutRoomId?: string) {
   const dayPreview = (time) => new Date(`2022-09-11T${time}:00.000-07:00`)
-  const dayOneDate = (time) => new Date(`2021-10-16T${time}:00.000-07:00`)
-  const dayTwoDate = (time) => new Date(`2021-10-17T${time}:00.000-07:00`)
+  const dayOneDate = (time) => new Date(`2022-10-22T${time}:00.000-07:00`)
+  const dayTwoDate = (time) => new Date(`2022-10-23T${time}:00.000-07:00`)
 
   if (day === 0) {
     return {
@@ -31,75 +31,56 @@ function ScheduleEntry (time: string, day: number, text: string, roomIds?: strin
   }
 }
 
-// 2022 Preview
-
-export const ScheduleEntries = [
-  ScheduleEntry('16:00', 0, 'Doors Open'),
-  ScheduleEntry('16:25', 0, 'Kickoff - Stream Begins', ['theater']),
-  ScheduleEntry('16:30', 0, 'Casey Yano, Mega Crit', ['theater'], 'mage'),
-  ScheduleEntry('17:00', 0, 'Justin Ma and Matthew Davis, Subset Games', ['theater'], 'rogue'),
-  ScheduleEntry('17:30', 0, SOCIAL_TIME),
-  ScheduleEntry('19:00', 0, 'Doors Close')
-]
-
-// 2021 entries, kept for formatting reminders for later
-
-// Saturday entries
-/*
 export const ScheduleEntries = [
   ScheduleEntry('09:00', 1, 'Doors Open'),
   ScheduleEntry('09:15', 1, 'Kickoff', ['theater']),
-  ScheduleEntry('09:30', 1, 'Michael Brough: Possibility of Roguelike Elements', ['theater'], 'mage'),
-  ScheduleEntry('10:00', 1, 'Jeremiah Reid: Juice Your Turns', ['theater'], 'rogue'),
+  ScheduleEntry('09:30', 1, 'Younès Rabii: "La Horde du Contrevent": A Novel That Didn\'t Know It Was A Roguelike', ['theater'], 'warrior'),
+  ScheduleEntry('09:45', 1, 'Sherveen Uduwana: Persistence and Resistence: How narrative in roguelikes is currently underutilized', ['theater'], 'mage'),
+  ScheduleEntry('10:00', 1, 'Florence Smith Nichols: Object Biographies: An Archaeological Approach to PCG', ['theater'], 'rogue'),
+  ScheduleEntry('10:15', 1, 'Tyler Robinson: Prototyping your games in Google Sheets', ['cleric'], ''),
   ScheduleEntry('10:30', 1, SOCIAL_TIME),
-  ScheduleEntry('11:00', 1, 'Brenda Romero: Dynamic Relationships and Traits in Empire of Sin', ['theater'], 'mage'),
-  ScheduleEntry('11:15', 1, 'Jasmine Otto: Cyclic Plot Generation in a Mixed-Initiative Narrative Instrument', ['theater'], 'rogue'),
-  ScheduleEntry('11:30', 1, 'Francesco Cottone: Chronicles of Stampadia and other postcards from an alternate world', ['theater'], 'tourist'),
-  ScheduleEntry('11:45', 1, 'Atty Vohra: Automating D&D Combat Prep with Roguelike Principles', ['theater'], 'warrior'),
+  ScheduleEntry('11:00', 1, 'Sonut Uzun: Procedural Music of Tea Garden', ['theater'], 'warrior'),
+  ScheduleEntry('11:30', 1, 'Janelle Shane: The Baltimore Orioles Effect: Hey! Stop poisoning my image prompt!', ['theater'], 'mage'),
   ScheduleEntry('12:00', 1, SOCIAL_TIME),
-  ScheduleEntry('13:00', 1, 'Arvi Teikari: Why Noita Became a Roguelite (and Why I Liked That a Lot)', ['theater'], 'mage'),
-  ScheduleEntry('13:30', 1, 'Shawn Main: You May Already Be a Roguelike', ['theater'], 'rogue'),
-  ScheduleEntry('14:00', 1, SOCIAL_TIME),
-  ScheduleEntry('14:30', 1, 'Jason Grinblat: Before you fix a leak ask if it\'s a fountain (a paean for bugs and edge cases)', ['theater'], 'tourist'),
-  ScheduleEntry('15:00', 1, 'Allie Signet & Joe Maliksi, Society for Internet Blaseball Research: SIBR - Sports, Splorts, and Statistics: Why Data Accessibility Matters in Blaseball and Beyond', ['theater'], 'mage'),
-  ScheduleEntry('15:30', 1, 'Evan Debenham: Community-Driven Roguelike Development', ['theater'], 'warrior'),
+  ScheduleEntry('13:00', 1, 'Dylan Gedig: Perfect Synergy: How Roguelike Developers and Streamers Form the Perfect Ecosystem', ['theater'], 'rogue'),
+  ScheduleEntry('13:30', 1, 'George Moromisato: Creating a Modding System for Roguelikes', ['theater'], 'cleric'),
+  ScheduleEntry('14:00', 1, 'Jeremy Rose: The Hitchhiker\'s Guide to the Cataclysm', ['theater'], 'warrior'),
+  ScheduleEntry('14:30', 1, SOCIAL_TIME),
+  ScheduleEntry('15:00', 1, 'Reed Lockwood: Common "Pitfalls" of Roguelike Traps and How to Circumvent Them', ['theater'], 'warrior'),
+  ScheduleEntry('15:15', 1, 'Chris King: How To Let Your Players Take The Wheel (without crashing the car)', ['theater'], 'mage'),
+  ScheduleEntry('15:30', 1, 'Benet Devereux: Seeking Treasure in the Tangled Bank: Biological Inspiration for Roguelike Mechanics ', ['theater'], 'rogue'),
+  ScheduleEntry('15:45', 1, 'Hannah Blair Salzman: Roguelikes, Neurodiversity, and Mental Illness', ['theater'], 'cleric'),
   ScheduleEntry('16:00', 1, SOCIAL_TIME),
-  ScheduleEntry('17:00', 1, 'Spencer Egart: Tooling for Roguelikes and Procgen', ['theater'], 'rogue'),
-  ScheduleEntry('17:15', 1, 'Thomas Robertson: Towards a New Understanding of Procedural Super Attacks', ['theater'], 'warrior'),
-  ScheduleEntry('17:30', 1, 'Dylan White: The Cost of Magic', ['theater'], 'mage'),
-  ScheduleEntry('17:45', 1, 'Qristy Overton: Exhibition: Attempting Brogue on a Dance Mat', ['theater'], 'tourist'),
-  ScheduleEntry('18:00', 1, SOCIAL_TIME),
-  ScheduleEntry('18:15', 1, 'Unconferencing', ['unconference']),
-  ScheduleEntry('19:00', 1, SOCIAL_TIME),
-  ScheduleEntry('20:45', 1, 'Doors Close')
-]
-*/
+  ScheduleEntry('16:30', 1, 'Jack Schlesinger: Your Puzzle Is A Secret Dungeon', ['theater'], 'mage'),
+  ScheduleEntry('17:00', 1, 'Sersa Victory: Choice Design in Roguelikes', ['theater'], 'rogue'),
+  ScheduleEntry('17:30', 1, SOCIAL_TIME),
+  ScheduleEntry('18:00', 1, 'Unconferencing', ['unconference']),
+  ScheduleEntry('19:00', 1, 'Doors Close'),
 
-/* export const ScheduleEntries = [
   ScheduleEntry('09:00', 2, 'Doors Open'),
   ScheduleEntry('09:15', 2, 'Kickoff', ['theater']),
-  ScheduleEntry('09:30', 2, 'Michael Langford: For the Squishies ⚡ Making Roguelikes Accessible to (Younger) Children and their Parents', ['theater'], 'warrior'),
-  ScheduleEntry('09:45', 2, 'Younès Rabii: Pokemon Glitch - Story of A Roguelike With No Author', ['theater'], 'tourist'),
-  ScheduleEntry('10:00', 2, 'Sraëka-Lillian: Procedural Phonology: Generating Name Generators', ['theater'], 'rogue'),
-  ScheduleEntry('10:15', 1, SOCIAL_TIME),
-  ScheduleEntry('10:30', 2, 'Unconferencing', ['unconference']),
-  ScheduleEntry('11:30', 2, 'Alice Lai: All Together Now: Creating Multiplicative Power in Hades', ['theater'], 'warrior'),
-  ScheduleEntry('12:00', 2, 'Brian Cronin: Off The Rails - Lessons Learned from Monster Train Development', ['theater'], 'rogue'),
-  ScheduleEntry('12:30', 2, SOCIAL_TIME),
-  ScheduleEntry('13:30', 2, 'Chris McCormick: Building Juicy Minimal Roguelikes in the Browser', ['theater'], 'mage'),
-  ScheduleEntry('14:00', 2, 'Rich Wilson: Roguelikes, Immersive Sims, and the Church of the Simulation', ['theater'], 'rogue'),
-  ScheduleEntry('14:30', 2, 'Xalavier Nelson Jr.: Building an Economic Flesh Simulation Will Make You Disassociate from Reality', ['theater'], 'tourist'),
-  ScheduleEntry('15:00', 2, SOCIAL_TIME),
-  ScheduleEntry('15:30', 2, 'Kristen Yu: Video Game Quest Theory for Improved Procedural Content Generation', ['theater'], 'mage'),
-  ScheduleEntry('16:00', 2, 'Ally Brinken & Michelle Webb, En Rogue: Who’s the Boss (And How and Why)?', ['theater'], 'warrior'),
-  ScheduleEntry('16:30', 2, 'John Harris: The Lost Roguelikes', ['theater'], 'rogue'),
+  ScheduleEntry('09:30', 2, 'Tabea Iseli: How hard can it be to create a non-violent rogue-lite dungeon crawler?', ['theater'], 'mage'),
+  ScheduleEntry('10:00', 2, 'Dustin Freeman: Simulating History as You’re Living Through It AKA Everyone is a Bunch of Concerns in a Trench Coat', ['theater'], 'rogue'),
+  ScheduleEntry('10:30', 2, SOCIAL_TIME),
+  ScheduleEntry('11:00', 2, 'Unconferencing', ['unconference']),
+  ScheduleEntry('12:00', 2, SOCIAL_TIME),
+  ScheduleEntry('12:30', 2, 'Philomena Schwab: This is too hard! How to broaden your game’s target audience with smart difficulty tricks', ['theater'], 'warrior'),
+  ScheduleEntry('12:45', 2, 'Adam Newgas: Constraint Based Generation is a swiss army knife', ['theater'], 'mage'),
+  ScheduleEntry('13:00', 2, 'Pierre Vigier: Room Generation using Constraint Satisfaction', ['theater'], 'rogue'),
+  ScheduleEntry('13:15', 2, 'Evan Debenham: Smoothing the Sharp Edges of RNG', ['theater'], 'cleric'),
+  ScheduleEntry('13:30', 2, SOCIAL_TIME),
+  ScheduleEntry('14:00', 2, 'Alexander Byaly: Causal Graphs for Procedural Generation', ['theater'], 'warrior'),
+  ScheduleEntry('14:30', 2, 'Abdelrahman Madkour: Controlling your generator using Expressive Range Analysis', ['theater'], 'mage'),
+  ScheduleEntry('15:00', 2, 'Phenry Ewing: A Million Little Players: Monte Carlo Simulations for Game Design', ['theater'], 'rogue'),
+  ScheduleEntry('15:30', 2, SOCIAL_TIME),
+  ScheduleEntry('16:00', 2, 'Sergio Garces: Procedural 3D environments on a budget', ['theater'], 'cleric'),
+  ScheduleEntry('16:30', 2, 'Joel Ryan: A Small Clump of Pixels: Creating the Sil-Q Tileset', ['theater'], 'mage'),
   ScheduleEntry('17:00', 2, SOCIAL_TIME),
-  ScheduleEntry('17:30', 2, 'Nick McConnell: Things I\'ve Learnt from Maintaining Angband', ['theater'], 'rogue'),
-  ScheduleEntry('17:45', 2, 'Nathan Savant: One Quest To Rule Them All: Quest Design in Non-Games Media', ['theater'], 'warrior'),
-  ScheduleEntry('18:00', 2, 'Noah Swartz: The Tombs of Atuan: The Original Roguelike?', ['theater'], 'mage'),
+  ScheduleEntry('17:30', 2, 'Cara Esten Hurtle: Telnet, a New Session, and transsexualizing the past', ['theater'], 'warrier'),
+  ScheduleEntry('17:45', 2, 'Santiago Zapata: Celebrating Moria - a roguelike before the roguelikes', ['theater'], 'rogue'),
   ScheduleEntry('18:15', 2, SOCIAL_TIME),
   ScheduleEntry('19:00', 2, 'Doors Close')
-] */
+]
 
 export default function ScheduleView () {
   const formatter = new Intl.DateTimeFormat('en', { hour: 'numeric', minute: 'numeric' })


### PR DESCRIPTION
- Adds a new schedule. 
- Adds some logic to automatically show the correct day of schedule (in the past, we pushed a commit after day 1 commenting it out and uncommenting out a previously-written day 2 schedule. Now, we check if it's at least 1 hour after the last event on day 1, and if so swap to day 2)
- Make a single place where we can fake out the current date to locally test both the schedule view and the "now happening" view
- The schedule now says whether it's day 1 or 2