### PR TITLE
add content-devvable modals to rooms

### DIFF
--- a/server/src/rooms/index.ts
+++ b/server/src/rooms/index.ts
@@ -41,6 +41,9 @@ export interface Room {
 
   // Array of users currently in this room
   users?: string[]
+
+  // text for a modal accessed by clicking a special link in the room description
+  specialFeatureText?: string
 }
 
 export interface NoteWallData {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,6 +56,7 @@ import _ from 'lodash'
 import BadgesModalView from './components/BadgesModalView'
 import BadgeUnlockModal from './components/BadgeUnlockModal'
 import DisconnectModalView from './components/DisconnectModalView'
+import SpecialTextModalView from './components/SpecialTextModalView'
 
 export const DispatchContext = createContext(null)
 export const UserMapContext = createContext(null)
@@ -352,6 +353,10 @@ const App = () => {
       const room = state.roomData[state.roomId]
       innerModalView = <RiddleModalView riddles={room.riddles}/>
       break
+    }
+    case Modal.SpecialFeatureText: {
+      const room = state.roomData[state.roomId]
+      innerModalView = <SpecialTextModalView text={room.specialFeatureText}/>
     }
   }
 

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -69,6 +69,12 @@ export default function RoomView (props: Props) {
     if (actionName) {
       linkActions[actionName]()
     }
+
+    const showModal =
+      e.target && e.target.getAttribute && e.target.getAttribute('data-modal')
+    if (showModal) {
+      dispatch(ShowModalAction(Modal.SpecialFeatureText))
+    }
   }
 
   const toggleRoomDescriptionClick = (e) => {
@@ -222,6 +228,8 @@ function parseDescription (
     const userCount = presenceData[roomId]
     if (roomId === 'item') {
       return `<a class='room-link' href='#' data-item='${text}'>${text}</a>`
+    } else if (roomId === 'showModal') {
+      return `<a class='room-link' href='#' data-modal='${roomId}'>${text}</a>`
     } else if (room) {
       const userCountString = userCount > 0 ? ` (${userCount})` : ''
       return `<a class='room-link' href='#' data-room='${roomId}'>${text}${userCountString}</a>`

--- a/src/components/SpecialTextModalView.tsx
+++ b/src/components/SpecialTextModalView.tsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function SpecialTextModalView (props: {text: string}) {
+  return (
+    <div id='riddle-modal' className='riddle-div'>
+      <p>{props.text}</p>
+    </div>
+  )
+}

--- a/src/modals.ts
+++ b/src/modals.ts
@@ -20,5 +20,6 @@ export enum Modal {
     HappeningNow,
     Riddles,
     Badges,
-    BadgeUnlock
+    BadgeUnlock,
+    SpecialFeatureText
 }

--- a/src/room.ts
+++ b/src/room.ts
@@ -20,6 +20,7 @@ export interface Room {
   notes?: RoomNote[]
   specialFeatures?: string[]
   riddles?: string[]
+  specialFeatureText?: string
 }
 
 export interface MinimalRoom {
@@ -39,7 +40,8 @@ export function convertServerRoom (room: Server.Room): Room {
     hidden: room.hidden,
     specialFeatures: room.specialFeatures,
     riddles: room.riddles,
-    users: room.users
+    users: room.users,
+    specialFeatureText: room.specialFeatureText
   }
 }
 


### PR DESCRIPTION
This lets someone add a link to a text modal via the roomData json:
* in the room description: [[my link text->showModal]]
* put the modal text in room.specialFeatureText (this is a terrible name, but it's late)

This does only support one modal per room, but I was told this was sufficient 