### PR TITLE
WIP: Migrate to ESM

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -22,7 +22,7 @@
         "@azure/functions": "^1.0.2-beta2",
         "@types/redis": "^2.8.24",
         "recursive-readdir": "^2.2.2",
-        "typescript": "^3.3.3"
+        "typescript": "^4.7"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -2355,9 +2355,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
-      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -4484,9 +4484,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
-      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "dev": true
     },
     "underscore": {

--- a/server/package.json
+++ b/server/package.json
@@ -2,6 +2,7 @@
   "name": "server",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "scripts": {
     "build": "tsc",
     "watch": "tsc -w",
@@ -25,6 +26,6 @@
     "@azure/functions": "^1.0.2-beta2",
     "@types/redis": "^2.8.24",
     "recursive-readdir": "^2.2.2",
-    "typescript": "^3.3.3"
+    "typescript": "^4.7"
   }
 }

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "ES2020",
     "target": "es6",
     "outDir": "dist",
     "rootDir": ".",
+    "moduleResolution": "node",
     "resolveJsonModule": true,
     "esModuleInterop": true,
     "sourceMap": true,


### PR DESCRIPTION
This:
- Upgrades our TS version for the latest goodness
- Sets `type: module` to tell Node that all .js files are ESM
- Tells TypeScript to emit ESM instead of commonJS

Not currently mergable because Azure Functions doesn't seem to support `type: module`. A few options:
1. Write a manual build script to rename all `.js` files to `.mjs`, and remove `type: module`
2. Use node's default HTTP module instead of node-fetch
3. Give up on our Discord mod bot integration
4. Hope I get a better answer internally