### PR TITLE
Fix locked custom emoji having broken images

### DIFF
--- a/server/src/badges.ts
+++ b/server/src/badges.ts
@@ -70,46 +70,46 @@ export const FreeBadges: Badge[] = [
   },
   {
     emoji: 'artificer',
-    description: 'Procgen Artificer',
+    description: 'Procgen Artificer: You get a tool, and you get a tool!',
     isCustom: true
   },
   {
     emoji: 'bard',
-    description: 'Procgen Bard',
+    description: 'Procgen Bard: Embrace the funky edges, make weird art!',
     isCustom: true
   },
   {
     emoji: 'cleric',
-    description: 'Procgen Cleric',
+    description: 'Procgen Cleric: It works if you run it twice... don\t ask why.',
     isCustom: true
   },
   {
     emoji: 'druid',
-    description: 'Procgen Druid',
+    description: 'Procgen Druid: Prune and shape your generator, watch it grow!',
     isCustom: true
   },
   {
     emoji: 'paladin',
-    description: 'Procgen Paladin',
+    description: 'Procgen Paladin: No, procedural does\'t just mean \'random\'',
     isCustom: true
   },
   {
     emoji: 'ranger',
-    description: 'Procgen Ranger',
+    description: 'Procgen Ranger: Guide your party around the oatmeal bogs!',
     isCustom: true
   },
   {
     emoji: 'sorceror',
-    description: 'Procgen Sorceror',
+    description: 'Procgen Sorceror: Generation is a conversation with yourself',
     isCustom: true
   },
   {
     emoji: 'warlock',
-    description: 'Procgen Warlock',
+    description: 'Procgen Warlock: Give the generator *whatever* it likes',
     isCustom: true
   }, {
     emoji: 'wizard',
-    description: 'Procgen Wizard',
+    description: 'Procgen Wizard: Gaze into the Abyss, understand WFC',
     isCustom: true
   }
 ]

--- a/src/components/BadgeView.tsx
+++ b/src/components/BadgeView.tsx
@@ -11,7 +11,7 @@ export default function BadgeView (props: {badge: Badge, isCustom?: boolean}) {
     return <span />
   }
 
-  const content = props.isCustom || b.isCustom
+  const content = props.isCustom
     ? <img alt={`${b.emoji} emoji`} className={`custom-badge badge-text-${b.emoji}`} src={customEmojiMap[b.emoji] ?? reservedEmojiMap[b.emoji]}/>
     : <span className={`badge-text-${b.emoji}`}>{b.emoji }</span>
 

--- a/src/components/BadgesModalView.tsx
+++ b/src/components/BadgesModalView.tsx
@@ -144,7 +144,7 @@ export default function BadgesModalView (props: Props) {
         onKeyDown={keyDownOnEquipped}
         role='button'
         tabIndex={0}>
-        {rawEquippedBadges[i] && <BadgeView key={`equipped-${i}`} badge={b} />}
+        {rawEquippedBadges[i] && <BadgeView key={`equipped-${i}`} badge={b} isCustom={b.isCustom} />}
       </div>
     )
   }
@@ -178,7 +178,7 @@ export default function BadgesModalView (props: Props) {
         role='button'
         tabIndex={0}
       >
-        <BadgeView badge={b} />
+        <BadgeView badge={b} isCustom={b.isCustom} />
       </span>
     )
   })


### PR DESCRIPTION
If the emoji was custom, then when it was trying to show the locked version, it would still match to b.isCustom and try to use an image. But the src won't be able to match anything valid, so it is a broken image. Switched it so that it relies on the isCustom coming from the props, so that we can make sure it's always false for locked badges.

Also added a bit of extra description to the proc gen practitioner badges