### PR TITLE
Support line breaks in special modal text

### DIFF
--- a/src/components/NameView.tsx
+++ b/src/components/NameView.tsx
@@ -147,7 +147,7 @@ export default function NameView (props: Props) {
   }
 
   const badges = (user.equippedBadges || [])
-    .map((b, i) => <BadgeView key={`badge-${i}`} badge={b} />)
+    .map((b, i) => <BadgeView key={`badge-${i}`} badge={b} isCustom={b.isCustom} />)
 
   // TODO: This is not yet being set anywhere
   if (user.isSpeaker) {

--- a/src/components/SpecialTextModalView.tsx
+++ b/src/components/SpecialTextModalView.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 
 export default function SpecialTextModalView (props: {text: string}) {
   return (
-    <div id='riddle-modal' className='riddle-div'>
-      <p>{props.text}</p>
+    <div id='bonus-modal'>
+      <p className="with-line-breaks">{props.text}</p>
     </div>
   )
 }

--- a/style/modal.css
+++ b/style/modal.css
@@ -53,3 +53,7 @@ th.break {
     border-width: 2px;
     border-color: var(--main-font);
 }
+
+#bonus-modal .with-line-breaks {
+    white-space: pre;
+}


### PR DESCRIPTION
Added a line of CSS so the bonus modal text could use `\n` where needed.