### PR TITLE
possible fix for room badge unlock

### DIFF
--- a/server/src/moveToRoom.ts
+++ b/server/src/moveToRoom.ts
@@ -120,7 +120,7 @@ export async function moveToRoom (
 
     if (awardedBadges.length > 0) {
       result.messages.push({
-        groupId: user.id,
+        userId: user.id,
         target: 'unlockBadge',
         arguments: [awardedBadges]
       })


### PR DESCRIPTION
When you enter a room with a badge, it's supposed to show you the modal saying "hey, you got a badge!" but it hasn't been. I'm guessing this is why? I don't know, but I definitely can't break it any worse 🤙