### PR TITLE
Alexei badge fix

### DIFF
--- a/src/components/BadgesModalView.tsx
+++ b/src/components/BadgesModalView.tsx
@@ -160,9 +160,9 @@ export default function BadgesModalView (props: Props) {
         className='locked-badge' draggable={true}
         key={b.emoji}
       >
-        <BadgeView emoji='🔒' description={b?.description} isCustom={b?.isCustom} />
+        <BadgeView emoji='🔒' description={b?.description} />
       </span>
-    )
+    ) // Purposefully leave out the isCustom field for locked badges, to avoid trying to render them as images
   })
 
   const unlockedBadges = (props.unlockedBadges || []).map((b, i) => {


### PR DESCRIPTION
The same fix as before - avoid treating locked badges as custom, so that we avoid trying to render them as images. (The alternative would be to have an image version of the lock, but this is easier for right now)