### PR TITLE
Allow rendered @-mentions in emotes and whispers

### DIFF
--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -49,7 +49,7 @@ export const ScheduleEntries = [
   ScheduleEntry('10:00', 1, 'Florence Smith Nichols: Object Biographies: An Archaeological Approach to PCG', ['theater'], 'rogue'),
   ScheduleEntry('10:15', 1, 'Tyler Robinson: Prototyping your games in Google Sheets', ['cleric'], ''),
   ScheduleEntry('10:30', 1, SOCIAL_TIME),
-  ScheduleEntry('11:00', 1, 'Sonut Uzun: Procedural Music of Tea Garden', ['theater'], 'warrior'),
+  ScheduleEntry('11:00', 1, 'Sonat Uzun: Procedural Music of Tea Garden', ['theater'], 'warrior'),
   ScheduleEntry('11:30', 1, 'Janelle Shane: The Baltimore Orioles Effect: Hey! Stop poisoning my image prompt!', ['theater'], 'mage'),
   ScheduleEntry('12:00', 1, SOCIAL_TIME),
   ScheduleEntry('13:00', 1, 'Dylan Gedig: Perfect Synergy: How Roguelike Developers and Streamers Form the Perfect Ecosystem', ['theater'], 'rogue'),


### PR DESCRIPTION
Previously, if you @-mention someone in a message that isn't a normal chat message, it gets rendered as the underlying @[[username]] syntax instead of actually rendering a NameView.

This ports the name parsing/rendering logic to EmoteView and WhisperView. It's possible this should be added to another message type, but as a gut check this seemed fine.

Possible this will cause additional rendering load, but it shouldn't.

<img width="887" alt="Screen Shot 2022-10-22 at 13 04 42" src="https://user-images.githubusercontent.com/821238/197353115-6b5b1215-1133-4892-b92c-63fca96bc962.png">
