### PR TITLE
[WIP] Post event fixes

### DIFF
--- a/server/src/endpoints/resetRoomData.ts
+++ b/server/src/endpoints/resetRoomData.ts
@@ -6,6 +6,12 @@ import { User } from '../user'
 
 const resetRoomData: AuthenticatedEndpointFunction = async (user: User, inputs: any, log: LogFn) => {
   // TODO: Allow this to just wipe a specific room
+
+  // First, delete all current rooms
+  const roomIds = await Redis.getRoomIds()
+  await Promise.all(roomIds.map(Redis.deleteRoomData))
+
+  // Then, add new data
   await Promise.all(Object.values(roomData).map(room => {
     return Redis.setRoomData(room as Room)
   }))

--- a/src/components/RoomListView.tsx
+++ b/src/components/RoomListView.tsx
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { FaVideo } from 'react-icons/fa'
+import { UserMapContext } from '../App'
 import { moveToRoom } from '../networking'
 
 import { Room } from '../room'
@@ -9,10 +10,12 @@ interface Props {
 }
 
 export default function RoomListView (props: Props) {
+  const { userMap, myId } = useContext(UserMapContext)
+
   const list = props.rooms
     .sort((a, b) => a.displayName.toLowerCase() > b.displayName.toLowerCase() ? 1 : -1)
     .map((r) => {
-      return r.hidden ? '' : <RoomListItem room={r} key={`room-sidebar-${r.id}`} />
+      return (r.hidden && !userMap[myId].isMod) ? '' : <RoomListItem room={r} key={`room-sidebar-${r.id}`} />
     })
 
   return (

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -101,7 +101,7 @@ export default function ScheduleView () {
   // If it's before the event or day 1, show day 1. Otherwise show day 2
   // TODO: This logic will need adjusting for a preview event
 
-  const endOfDayOne = ScheduleEntries.slice().reverse().find(e => e.day === 1).time
+  const endOfDayOne = new Date(ScheduleEntries.slice().reverse().find(e => e.day === 1).time)
   endOfDayOne.setTime(endOfDayOne.getTime() + (1 * 60 * 60 * 1000)) // Add 1 hour after the last event
 
   let day = 2


### PR DESCRIPTION
I've been banging on a few small issues that have popped up during the event (noted in our Discord thread). These are issues that I think it doesn't make sense to try to push out during the 2022 event, but keeping this updated as a recurring list of fixes we can merge + test after the event.

- Shows hidden rooms in the room list if you're a mod
- Choosing to reset the room data to the disk copy will delete all rooms first, meaning rooms that have been deleted from roomData.json but still exist in Redis will be deleted
- Fixes the schedule view so the day one "doors close" time won't freak out and keep getting later and later