### PR TITLE
Fix apos in Twitter note

### DIFF
--- a/src/components/LoggedOutView.tsx
+++ b/src/components/LoggedOutView.tsx
@@ -40,9 +40,9 @@ export default function LoggedOutView () {
         </p>
         <StyledFirebaseAuth uiConfig={uiConfig} firebaseAuth={firebase.auth()} />
         <p>
-          If you logged in with Twitter in previous years, we&pos;re sorry but
+          If you logged in with Twitter in previous years, we&apos;re sorry but
           due to the recent unpleasantness, our Twitter integration has ceased
-          to function. You&pos;ll have to create a new account via email or Google.
+          to function. You&apos;ll have to create a new account via email or Google.
           Sorry for the trouble.
         </p>
         <p>


### PR DESCRIPTION
<img width="1271" alt="Screenshot 2023-09-09 at 6 12 00 PM" src="https://github.com/Roguelike-Celebration/azure-mud/assets/821238/e0e8aecd-1724-4325-99eb-a8c999be194c">

This is just a small typo, fixing a few instances of `&pos;` to `&apos;`, the actual escape code.