### PR TITLE
Fix move desyncs for multiple clients

### DIFF
--- a/src/components/EmailVerifiedView.tsx
+++ b/src/components/EmailVerifiedView.tsx
@@ -1,7 +1,4 @@
-import React, { useContext } from 'react'
-import { DispatchContext } from '../App'
-import { AuthenticateAction, HideSideMenuAction } from '../Actions'
-import config from '../config'
+import React from 'react'
 import firebase from 'firebase/app'
 import 'firebase/auth'
 

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -212,27 +212,14 @@ export async function connect (
 }
 
 export async function moveToRoom (roomId: string) {
+  // We used to use the result, but we now use PubSub instead, receiving updatedCurrentRoom.
+  // A lot of other stuff still uses HTTP results - ideally we'd just use PubSub.
   const result: RoomResponse | ErrorResponse | any = await callAzureFunction(
     'moveRoom',
     {
       to: roomId
     }
   )
-
-  console.log(result)
-
-  if (result) {
-    myDispatch(
-      UpdatedCurrentRoomAction(
-        result.roomId,
-        convertServerRoomData(result.roomData)
-      )
-    )
-
-    if (result.roomNotes) {
-      myDispatch(NoteUpdateRoomAction(result.roomId, result.roomNotes))
-    }
-  }
 }
 
 export async function sendChatMessage (id: string, text: string) {
@@ -422,6 +409,18 @@ function generateEventMapping (userId: string, dispatch: Dispatch<Action>) {
     playerDisconnected: (otherId) => {
       console.log('Player left!', otherId)
       dispatch(PlayerDisconnectedAction(otherId))
+    },
+    updatedCurrentRoom: (data) => {
+      myDispatch(
+        UpdatedCurrentRoomAction(
+          data.roomId,
+          convertServerRoomData(data.roomData)
+        )
+      )
+
+      if (data.roomNotes) {
+        myDispatch(NoteUpdateRoomAction(data.roomId, data.roomNotes))
+      }
     },
     presenceData: (data) => {
       dispatch(UpdatedPresenceAction(data))


### PR DESCRIPTION
Still keeps the HTTP request for moving rooms, but moves contents into PubSub so it reaches all clients.

Doesn't fix weird text desync issues but that's MUCH more minor.

![beforemove](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/ccea7c92-164e-4b48-a80c-37090459a916)
![aftermove](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/b6f6046c-54eb-4bf7-a1f1-50efee8e0141)
![withmap](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/dae9af9a-a8ff-4c19-bce1-77610b1ead0e)