### PR TITLE
Fix login nonresponse

### DIFF
--- a/server/src/endpoints/connect.ts
+++ b/server/src/endpoints/connect.ts
@@ -61,13 +61,18 @@ const connect: AuthenticatedEndpointFunction = async (user: User, inputs: any, l
   }
 
   result.groupManagementTasks = [
-    ...await setUpRoomsForUser(user.id, user.roomId),
-    {
-      userId: user.id,
-      groupId: user.roomId,
-      action: 'add'
-    }
+    ...await setUpRoomsForUser(user.id, user.roomId)
   ]
+
+  // Originally this was placed in the above assignment behind the spread operator
+  // For whatever reason this would lead to fresh logins being unable to see text
+  // I don't know why it's insane that moving this into a push works! Is there some sort of lazy evaluation going on
+  // that the push forces!?
+  result.groupManagementTasks.push({
+    userId: user.id,
+    groupId: user.roomId,
+    action: 'add'
+  })
 
   if (await isMod(user.id)) {
     result.groupManagementTasks.push({

--- a/server/src/moveToRoom.ts
+++ b/server/src/moveToRoom.ts
@@ -69,11 +69,6 @@ export async function moveToRoom (
     }
   }
 
-  // We send presence data as a SignalR message as part of this HTTP call
-  // HOWEVER! Our client isn't smart enough to merge things correctly
-  // if it gets that presence message BEFORE the HTTP request returns, which is likely
-  // There are potentially better ways to solve this, but making sure the HTTP response
-  // contains presence data is ~fine~
   to.users = await DB.roomOccupants(to.id)
 
   const awardedBadges = awardBadges(user, to.id)

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -548,7 +548,7 @@ export async function connectPubSub (eventMapping: {
   const ws = new WebSocket(result.url)
   // TODO: Handle error and close
   ws.addEventListener('open', () => {
-    console.log('Conneted to PubSub Service')
+    console.log('Connected to PubSub Service')
     // Note status
   })
   ws.addEventListener('message', (event) => {


### PR DESCRIPTION
This is an insanely bonkers fix, I have no real theory on how it works other than mumble mumble lazy evaluation, and I'm not sure it'll work on prod because with no theory on how it works how can I say with confidence? but here we are.

Behavior with main deployed:
![brokenlogin](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/f5d1fb34-373f-4821-9187-7100f2b214d0)
![brokenbroken](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/8b6570ac-7e41-4972-b341-75475623425a)

With fix deployed:
![fixedlogin](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/4e033a29-d6f3-4915-be1e-8bb5d6ad104e)
![fixedfixed](https://github.com/Roguelike-Celebration/azure-mud/assets/1434086/41f048e5-37ab-492f-955d-66c3ef450895)

