### PR TITLE
SlashCommand: tell the user when a parameter to a cmd is missing

### DIFF
--- a/src/SlashCommands.ts
+++ b/src/SlashCommands.ts
@@ -1,4 +1,4 @@
-interface SlashCommand {
+export interface SlashCommand {
     type: string;
     description: string;
     invocations: string[];
@@ -36,10 +36,13 @@ export const SlashCommands: SlashCommand[] = [
   SlashCommand(SlashCommandType.Interact, 'Interact with or get something in a room by referencing the name in the description - experiment as you explore!', ['/interact', '/get'], false)
 ]
 
-export function matchingSlashCommand (message: String): SlashCommand | undefined {
-  return SlashCommands.find((command) =>
-    command.invocations.find((invocation) =>
-      command.singleParameter ? message.startsWith(invocation) : message.startsWith(invocation + ' ')
-    )
-  )
+export function matchingSlashCommand (cmd: string, arg: string | undefined): SlashCommand | 'SlashCommandArgumentExpected' | 'UnregisteredSlashCommand' {
+  const found = SlashCommands.find((command) => command.invocations.find((inv) => cmd === inv))
+  if (found === undefined) {
+    return 'UnregisteredSlashCommand'
+  }
+  if (!found.singleParameter && arg === undefined) {
+    return 'SlashCommandArgumentExpected'
+  }
+  return found
 }

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -42,7 +42,7 @@ import {
   updateProfileColor
 } from './networking'
 import { Room } from './room'
-import { matchingSlashCommand, SlashCommandType } from './SlashCommands'
+import { matchingSlashCommand, SlashCommand, SlashCommandType } from './SlashCommands'
 import * as Storage from './storage'
 import { EntityState } from './types'
 
@@ -170,9 +170,9 @@ export default produce((draft: State, action: Action) => {
 
     if (
       original(draft).serverSettings.movementMessagesHideRoomIds !==
-        current(draft).serverSettings.movementMessagesHideRoomIds ||
+      current(draft).serverSettings.movementMessagesHideRoomIds ||
       original(draft).serverSettings.movementMessagesHideThreshold !==
-        current(draft).serverSettings.movementMessagesHideThreshold
+      current(draft).serverSettings.movementMessagesHideThreshold
     ) {
       draft.messages.ids = filteredMessageIds(draft)
     }
@@ -496,10 +496,7 @@ export default produce((draft: State, action: Action) => {
   if (action.type === ActionType.SendMessage) {
     const messageId: string = uuidv4()
     const trimmedMessage = action.value.trim()
-    const beginsWithSlash = /^\/.+?/.exec(trimmedMessage)
-    const matching = beginsWithSlash
-      ? matchingSlashCommand(trimmedMessage)
-      : undefined
+    const slashCommandTokens = /^(\/\w+)(?:\s+(.+))?/.exec(trimmedMessage)
 
     if (trimmedMessage.length > MESSAGE_MAX_LENGTH) {
       addMessage(
@@ -508,59 +505,68 @@ export default produce((draft: State, action: Action) => {
           'Your message is too long! Please try to keep it under ~600 characters!'
         )
       )
-    } else if (beginsWithSlash && matching === undefined) {
-      const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
-      addMessage(
-        draft,
-        createErrorMessage(
-          `Your command ${
-            commandStr ? commandStr[1] : action.value
-          } is not a registered slash command!`
-        )
-      )
-    } else if (beginsWithSlash && matching.type === SlashCommandType.Whisper) {
-      const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
-      const parsedUsernameMessage = /^(.+?) (.+)/.exec(commandStr[2])
+    } else if (slashCommandTokens !== null) {
+      // Handle server commands
+      const cmdToken = slashCommandTokens[1]
+      const cmdArg = slashCommandTokens.length > 1 ? slashCommandTokens[2] : undefined
+      const cmd = matchingSlashCommand(cmdToken, cmdArg)
 
-      if (!parsedUsernameMessage) {
+      if (cmd === 'UnregisteredSlashCommand') {
         addMessage(
           draft,
-          createErrorMessage(`Your whisper to ${commandStr[2]} had no message!`)
+          createErrorMessage(`Your command ${cmdToken} is not a registered slash command!`)
+        )
+      } else if (cmd === 'SlashCommandArgumentExpected') {
+        addMessage(
+          draft,
+          createErrorMessage(`Your command ${cmdToken} expected an argument!`)
         )
       } else {
-        sendChatMessage(messageId, trimmedMessage)
+        const sc = cmd as SlashCommand
 
-        const [_, username, message] = parsedUsernameMessage
-        const user = Object.values(draft.userMap).find(
-          (u) => u.username === username
-        )
-        const userId = user && user.id
-        if (userId) {
-          const whisperMessage = createWhisperMessage(userId, message, true)
-          addMessage(draft, whisperMessage)
-          saveWhisper(draft, whisperMessage)
+        if (sc.type === SlashCommandType.Whisper) {
+          const parsedUsernameMessage = /^(\w+)\s+(.+)/.exec(cmdArg)
+          if (!parsedUsernameMessage) {
+            addMessage(
+              draft,
+              createErrorMessage(`Your whisper to ${cmdArg} had no message!`)
+            )
+          } else {
+            sendChatMessage(messageId, trimmedMessage)
+
+            const [_, username, message] = parsedUsernameMessage
+            const user = Object.values(draft.userMap).find(
+              (u) => u.username === username
+            )
+            const userId = user && user.id
+            if (userId) {
+              const whisperMessage = createWhisperMessage(userId, message, true)
+              addMessage(draft, whisperMessage)
+              saveWhisper(draft, whisperMessage)
+            }
+          }
+        } else if (sc.type === SlashCommandType.Help) {
+          draft.activeModal = Modal.Help
+          addMessage(
+            draft,
+            createCommandMessage(
+              'You consult the help docs. (You can also find them in sidebar!)'
+            )
+          )
+        } else if (sc.type === SlashCommandType.Look) {
+          addMessage(
+            draft,
+            createCommandMessage(
+              `You attempt to examine ${cmdArg}. (You can also click on their username and select Profile!)`
+            )
+          )
+          sendChatMessage(messageId, trimmedMessage)
+        } else {
+          sendChatMessage(messageId, trimmedMessage)
         }
       }
-    } else if (beginsWithSlash && matching.type === SlashCommandType.Help) {
-      draft.activeModal = Modal.Help
-      addMessage(
-        draft,
-        createCommandMessage(
-          'You consult the help docs. (You can also find them in sidebar!)'
-        )
-      )
-    } else if (beginsWithSlash && matching.type === SlashCommandType.Look) {
-      const commandStr = /^(\/.+?) (.+)/.exec(trimmedMessage)
-      addMessage(
-        draft,
-        createCommandMessage(
-          `You attempt to examine ${commandStr[2]}. (You can also click on their username and select Profile!)`
-        )
-      )
-      sendChatMessage(messageId, trimmedMessage)
-    } else if (beginsWithSlash) {
-      sendChatMessage(messageId, trimmedMessage)
     } else {
+      // Handle an ordinary chat message
       sendChatMessage(messageId, action.value)
       addMessage(
         draft,


### PR DESCRIPTION
This is a fresh PR matching #835.

--

Hello!

This is my attempt at addressing the main issue that I filed https://github.com/Roguelike-Celebration/azure-mud/issues/829 . This patch does not touch any of the subsequent comments in that issue (I do not warn if an extraneous argument is passed to a single-parameter command or attempt to deal with malformed slash commands like simply typing /; nor do I touch anything on the backend). matchingSlashCommand now returns, morally, a union: either a successful SlashCommand object or one of two failure strings, which the caller matches on. This allowed the caller's logic to be simplified a bit, which is nice.

I am not a typescript person (or, really, a frontend person at all) so I hope this is an idiomatic solution. [here](https://www.typescriptlang.org/play?#code/JYOwLgpgTgZghgYwgAgMoBs4GcAWBhAewFsi4QATZAbwChl7kwBPABwgC5kswpQBzANx0G5CFgS8WYYARCduvEIOH1QANwII402Vnk9+AbQC6Qhl37oIABThQ4RCJCicARgQJWyQgL40aCLpgaJi4hCRklAC8yAAUwiAOHFwGSgA0wqLikjpyKYp8GaogGlq5evlGxkUWSla29o7Obh5eIDQAlJwY2PjEpBTIUQB81MhQTgCuUCBjzGyciY5pyFkSwFIyeWs5WyvqmtpbFQdlxytYljZ2Sc21fPU3TdDIPq-+ECCTRCG94QPkAAqrBQtHoAAkIOgWENkABycEAUQAMtY4TUALIENQoGJwjEAeQAaoj0cIAOo4YBYNhQWFw8nggCSqGsiIASmT6KgcARJsE8ahwQSAKqArnIRFEAiQemIwmA0k1AAiZCQ9OVAEEAHJ4JXCJngaCIAXwpnaxXszV4cU1QjgE1Y6LwvAEi3WwEAfUJyolyI8AGt6ciCQSANJwmh+AJBX5hfqRCo9eMRCgmWGGYTJvqp8ixbP-SLAtgAOkh0JWcOR1LAWEYOBQcDUcGAmFcVmQgVzWHRyEMcIA9A3oXDqowoJMIB0agWExR86EcwDixAS1icZX1ygYFBiMhZChd3uwARkGQZQ2oCXkABNPmdshn9BYU8IdDABBB2T1lDvkBB0Af3GDwfh2DZchLXt+wHPgCF7QdpRxUcVngZ8pxnRdC3nWdcxXEtKWpWlKwImkXnPMBL2QSYsGga870mB9ZjgZ9X3fT9VmACYEDAdAmH3WYKIgTjkCWRtBhoqxuKAgB3KlSLpAhNlkSCVmg2TCOgZDkFQmjpyzTC5zzHDlxBEseT5MBK1QT5yDrOBkEcLAsDgPgUBPZAIBxKAmHccg+O0fj1QAWmQHBsDPZAAFYHNAfkUECTxyAIaSQGvZVTxAGUz1cai3LkgBCKDB1wCytJ09D9L+QyFyq3DTKlGUIErasA0bESCCgUh0AcsRnNclYcuCQDgDAZiPywQrVMHCBpUgeCB0cMrmN0jDaoBGqUxM0tVRAJBKwAIWo4J7MQiBJr7QdyDVCAtJ4Sc9O5Azcw2pci1M+1Ru4p0rJsuyeqcly3NPQSHIIShIAca9yRQaTW261wUEAk9JgQHAuF5KAeP8mBnGkuxbJUi6FrB+bpVs0mweNE8oAp0R7Gpnsx3Kh641e7Cnq21d-QIANKyJYAIGkoCWF3GBWxQAgYDPTLBLpXKr1ve8tCYljOzYr8BIbYTROlygJIgKSQesUXxf3JTUqKgd0EDJa0JZ4zIherCgVMw1nBNSs3eNKTYYo-c6Vc4IXyaKklGQQD7KPH5XD4iYYGgT4EH4ICdaRhtVjEdZzeQEKIAAD1pYBHHAM86yYe985Ya2JnO6DQHd7j5sD23dJoYx-BgSZdtyBztFR-gHcGWIECIch9AKFY7D4cfk4AHyoigIDFkAIHILpWed5B54AIkH8hNSgPhvk+MBEQLg3IHIbet+QbeRRACY+BrBPyD36+wU7WMYD5QYYj3rASzLzzMPQyHQhijC7ACEspwji6EAaAYB6gwEjE7KPIYMQkEdGEMAKWsRv5d2iFEGIBCl6gFXmAj+9AJhgGmLMO+D8IBP24C-N+wg-CqFwflfBFASyXDqNcRoTgXgADJhFnkPug4hi9l7kOoCocYUwZi3z3gfI+xdT7n24qvbebDhDUNodpH+5Aowdy7txLYjAxBgFiEQLA09KhKAofIwIIBuDjiLo4cgGJeqA1hLYvgJYDBEFiFg8wLi3EnlaiAYAAAvVesIBwAD1YgAB0BwpOkgAag6LEAA-OwFJWBMmxBLNkjouSBwlnzgbWIQTPHeIBq5UJDBwnBBHkCHmnxYSRM+LE1ehgACM7cwmxnaao7pnTolxPICWKwSg-ajAGcgXJjBJl9PIIYAATMYZAnASEyOMeYfRSjDDtMBJMlYYzD4rFIGAfuSg97D1HucqJlzR6qI6O3Ex-hwmeFXNbPgtSrGxG3gOdS8lzAMAdEwau9AqQMGHNbZA0kOroCvh0LBvyrCzIIICyA3AQVgrkrSbeGKYyuL+TivFwLQXDhhOYfOPAyAQD5HZQ+pKsEDgHFi-5uKgUEtBRy5AXLkB8G0PEtOKBrDsnrLuSYfA0YAANzBvChDRcOuCsAcyLJMus+UiEiUmOgdAFDFVAA) is a REPL with some tests.

I was hoping that I'd be able to attach a local frontend to the running backend during this week's Celebration, but it looks like from the README that I still require an API key and a FireBase thingie to do so? If there's a trivial way of pointing it to prod then I'm happy to test it that way, of course.