### PR TITLE
Hopefully fix the 500 in prod

### DIFF
--- a/server/src/moveToRoom.ts
+++ b/server/src/moveToRoom.ts
@@ -113,7 +113,7 @@ export async function moveToRoom (
       {
         groupId: to.id,
         target: 'playerEntered',
-        arguments: [user.id, user.roomId, currentRoom.shortName]
+        arguments: [user.id, user.roomId, currentRoom.shortName || 'undefined']
       },
       {
         userId: user.id,


### PR DESCRIPTION
If getRoomData was returning undefined it would error. I think this happened because the room may have been wiped in the interim, and normally the client would handle this when connecting by placing into entryway.