### PR TITLE
Update .vscode's source.fixAll setting to strings for VS Code 1.85+

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,6 @@
   "debug.internalConsoleOptions": "neverOpen",
   "azureFunctions.preDeployTask": "npm prune",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   }
 }


### PR DESCRIPTION
The valid values for .vscode/settings.json's source.fixAll were changed from true/false booleans to "explicit"/"always"/"never" strings [in VS Code 1.85](https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto). When launching VS Code on a project like this with an old boolean value in source.fixAll, it'll [automatically change](https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own) it to the equivalent new string value, introducing a diff without user action. Updating the value in the repo will keep that distracting automatic change from happening. VS Code is currently at version 1.99, and 1.85 was released in November 2023, so all our devs are likely to be on 1.85 or later.

See:
  * https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own
  * https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto