### PR TITLE
License: fix author name, add years after 2020, and note in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2020 Microsoft
+Copyright (c) 2020, 2021, 2022, 2023, 2024, 2025 Roguelike Celebration Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -221,6 +221,10 @@ A moderator has the ability to make any other user a mod by clicking their usern
 
 If that user reloads the space, they will now be a mod and have the ability to add other mods.
 
+## License
+
+The contents of this repo are licensed under the MIT License. See the `LICENSE` file for details.
+
 ## Contributions
 
 If you're looking to get involved: awesome! There's a "Good First Issue" tag in this repo's GitHub Issues that may point you towards something. If you want to work on something, it might be nice to comment that you're looking into it in case others are already working on it or were thinking about it.


### PR DESCRIPTION
I don't think Microsoft wrote this code. :) I just guessed at "Roguelike Celebration Contributors" as a suitable collective author name.

Added years where more code was written to the copyright notice.

Noted the licensing type in the README. That text in `LICENSE` looks like the MIT License.