### PR TITLE
Attempting to remove webpubsub comms temporarily

### DIFF
--- a/server/src/azureWrap.ts
+++ b/server/src/azureWrap.ts
@@ -45,6 +45,9 @@ function outputToAzure (context: Context, req: HttpRequest, result: Result) {
   context.log('outputting to azure')
   context.log('context: ', JSON.stringify(context))
   context.log('result: ', JSON.stringify(result))
+
+  context.bindings.actions = []
+  /*
   if (result.messages) {
     context.bindings.actions = result.messages.map((m) => {
       const actionJson = JSON.stringify({ type: m.target, value: m.arguments })
@@ -95,6 +98,7 @@ function outputToAzure (context: Context, req: HttpRequest, result: Result) {
   }
 
   console.log('actions', JSON.stringify(context.bindings.actions))
+  */
 
   // TimerTriggers don't have a res obj. This seems like an okay, if imperfect, guard.
   if (context.res) {

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -243,6 +243,7 @@ export async function moveToRoom (roomId: string) {
       to: roomId
     }
   )
+  window.location.reload()
 }
 
 export async function sendChatMessage (id: string, text: string) {


### PR DESCRIPTION
What this does is essentially turns off WebPubSub. This breaks:
* moving between rooms without refreshing
* all users communications
* seeing other users

However, it allows people to:
* log in
* move between rooms with a page refresh after move

I think this is improved Enough to allow for limited content development, and it doesn't make anything _worse_ per se...