### PR TITLE
Fix Web PubSub by ensuring PubSub user exists before AFA connect/ call

### DIFF
--- a/server/src/azureWrap.ts
+++ b/server/src/azureWrap.ts
@@ -45,9 +45,6 @@ function outputToAzure (context: Context, req: HttpRequest, result: Result) {
   context.log('outputting to azure')
   context.log('context: ', JSON.stringify(context))
   context.log('result: ', JSON.stringify(result))
-
-  context.bindings.actions = []
-  /*
   if (result.messages) {
     context.bindings.actions = result.messages.map((m) => {
       const actionJson = JSON.stringify({ type: m.target, value: m.arguments })
@@ -98,7 +95,6 @@ function outputToAzure (context: Context, req: HttpRequest, result: Result) {
   }
 
   console.log('actions', JSON.stringify(context.bindings.actions))
-  */
 
   // TimerTriggers don't have a res obj. This seems like an okay, if imperfect, guard.
   if (context.res) {

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -203,6 +203,10 @@ export async function connect (
   myUserId = userId
   myDispatch = dispatch
 
+  // connectPubSub must be called before AFA connect/, because it auto-creates the PubSub
+  // user that connect/ and other azureWrap-ed functions depend on.
+  const eventMapping = generateEventMapping(userId, dispatch)
+  await connectPubSub(eventMapping)
   const result: RoomResponse = await callAzureFunction('connect')
 
   console.log(result)
@@ -223,9 +227,6 @@ export async function connect (
   if (result.unlockableBadges) {
     dispatch(UpdateUnlockableBadgesAction(result.unlockableBadges))
   }
-
-  const eventMapping = generateEventMapping(userId, dispatch)
-  await connectPubSub(eventMapping)
 
   // "serverSettings" is a handled SignalR action
   // So we should just automatically send this down on `connect`


### PR DESCRIPTION
Addresses the https://github.com/Roguelike-Celebration/azure-mud/issues/899 breakage, using @lazerwalker's idea of pulling `conectPubSub()` up in `connect()`.

* Restore use of Web PubSub.
* Have networking.connect() call connectPubSub() before AFA connect/, to ensure the PubSub user exists.

If the PubSub user doesn't exist when connect/ is called, it may get error 500s from its azureWrap trying to do group-management things on the nonexistent user. Looks like it is the PubSub client connection creation that causes PubSub users to be auto-created. So do the connectPubSub() before calling any azureWrap-ed AFA functions, including connect/.

With this patch, on my test instance, the 500 errors are gone, I can see room content, and room chat between multiple users seems to be working. Whisper chat seems to work. Screenshot here shows fennel in Firefox and apjanke-1 in Chrome. 

<img width="2372" alt="image" src="https://github.com/user-attachments/assets/41b18237-fedf-41d7-8b38-3c82d483dd4d" />
