### PR TITLE
Sync client & server when broadcasting messages

### DIFF
--- a/server/src/endpoints/heartbeat.ts
+++ b/server/src/endpoints/heartbeat.ts
@@ -58,6 +58,8 @@ const heartbeat: EndpointFunction = async (inputs: any, log: LogFn) => {
   }
 
   return {
+    // Maybe we should put the roomId in here, so that we can forcibly sync the user to rooms if the client has old or
+    // bad data.
     messages: [
       {
         target: 'ping',

--- a/server/src/endpoints/sendChatMessage.ts
+++ b/server/src/endpoints/sendChatMessage.ts
@@ -124,7 +124,10 @@ const sendChatMessage: AuthenticatedEndpointFunction = async (user: User, inputs
 
   return {
     messages,
-    httpResponse: { status: 200 }
+    httpResponse: {
+      status: 200,
+      body: { roomId: user.roomId }
+    }
   }
 }
 

--- a/server/src/moveToRoom.ts
+++ b/server/src/moveToRoom.ts
@@ -86,11 +86,10 @@ export async function moveToRoom (
   const result: Result = {
     httpResponse: {
       status: 200,
-      // Instead of returning relevant data in the HTTP response, we use websockets.
-      // This helps dealing with desyncs.
-      // Unfortunately things like outgoing whispers/messages still encounter desyncs.
-      // 'least it's obvious!
-      body: undefined
+      // We want to use the HTTP return as little as possible, and use websockets more - this helps dealing with
+      // desyncs. However, we want to return the roomId to allow for integrity checking on the client side.
+      // Unfortunately things like outgoing whispers/messages still encounter desyncs. That's on the to-do list.
+      body: { roomId: to.id, moved: true }
     }
   }
 

--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -68,7 +68,8 @@ export default function RoomView (props: Props) {
     const actionName =
       e.target && e.target.getAttribute && e.target.getAttribute('data-action')
     if (actionName) {
-      linkActions[actionName]()
+      // roomId is required because some of these send messages to the server
+      linkActions[actionName](roomId)
     }
 
     const showModal =

--- a/src/linkActions.ts
+++ b/src/linkActions.ts
@@ -11,14 +11,14 @@ export const linkActions = {
   pickUpPuppy: () => {
     pickUpItem('a tiny puppy')
   },
-  drinkPolymorph: () => { // Listen. Is this the correct way? No. Does it save me needing to write a new httpTrigger? Yes.
-    sendChatMessage(uuidv4(), '/get colourful potion')
+  drinkPolymorph: (roomId: string) => { // Listen. Is this the correct way? No. Does it save me needing to write a new httpTrigger? Yes.
+    sendChatMessage(uuidv4(), '/get colourful potion', roomId)
   },
-  drinkCancellation: () => {
-    sendChatMessage(uuidv4(), '/get clear potion')
+  drinkCancellation: (roomId: string) => {
+    sendChatMessage(uuidv4(), '/get clear potion', roomId)
   },
-  getFortune: () => {
-    sendChatMessage(uuidv4(), '/get fortune cookie')
+  getFortune: (roomId: string) => {
+    sendChatMessage(uuidv4(), '/get fortune cookie', roomId)
   },
   readPoster: () => {
     displayMessageFromList('motivationPosters')

--- a/src/networking.ts
+++ b/src/networking.ts
@@ -269,9 +269,14 @@ export async function sendChatMessage (id: string, text: string, currentRoomId: 
   // and the server thinks you're in a different room than you are. This may be one of the reasons there are issues
   // with users being unable to hear messages while still being able to send messages. We force a move in those
   // situations, forcing the server to shift to this room.
+  //
+  // You can reproduce by having one user account logged in on two computers, adding a delay into the server, then
+  // having it switch rooms & cutting the internet on one, so that only one gets the websockets move. After you go back
+  // online type something. Until you do that, it won't be able to see any messages.
   if (result && result.roomId && !result.moved && result.roomId !== currentRoomId) {
     console.error(`Client/server room desync! Client roomId: ${currentRoomId} - Server roomId: ${result.roomId}.`)
-    await moveToRoom(currentRoomId)
+    await moveToRoom(currentRoomId) // Sync the server
+    window.location.reload() // Unless you do this, the client can't see chat - I'm not sure on the exact reason.
   }
 
   // Other non-message actions

--- a/src/reducer.ts
+++ b/src/reducer.ts
@@ -533,7 +533,7 @@ export default produce((draft: State, action: Action) => {
           createErrorMessage(`Your whisper to ${commandStr[2]} had no message!`)
         )
       } else {
-        sendChatMessage(messageId, trimmedMessage)
+        sendChatMessage(messageId, trimmedMessage, draft.roomId)
 
         const [_, username, message] = parsedUsernameMessage
         const user = Object.values(draft.userMap).find(
@@ -562,11 +562,11 @@ export default produce((draft: State, action: Action) => {
           `You attempt to examine ${commandStr[2]}. (You can also click on their username and select Profile!)`
         )
       )
-      sendChatMessage(messageId, trimmedMessage)
+      sendChatMessage(messageId, trimmedMessage, draft.roomId)
     } else if (beginsWithSlash) {
-      sendChatMessage(messageId, trimmedMessage)
+      sendChatMessage(messageId, trimmedMessage, draft.roomId)
     } else {
-      sendChatMessage(messageId, action.value)
+      sendChatMessage(messageId, action.value, draft.roomId)
       addMessage(
         draft,
         createChatMessage(messageId, draft.userId, action.value)


### PR DESCRIPTION
We have a longstanding issue with the chat sometimes just vanishing; as discussed at our last meeting 2025-08-24 when the client thinks you're in one room and the server thinks you're in another, this PR will force a move to the room which the client thinks you're in, then refresh the page. This will resolve the desync and allow you to see chat.

Note that we _do_ have a heartbeat function which would also be a good place to put this code and that's another good candidate.

An issue here is that by putting the roomId data back into the http response of move and send message, we're going backwards from our desired goal of having websockets be the main form of communication. However the issue with websockets is that it does not replay broadcasts - if you're out of connection, it'll just drop the messages - so...it's structural.

Here's the images
**After moving on my laptop & cutting the internet - main computer images have as picnic ground and laptop as taco truck**
<img width="2031" height="953" alt="bothpicnic" src="https://github.com/user-attachments/assets/8478d1a9-3509-4bf2-aa21-ec9402a6cc62" />

**After typing something on my laptop & moving the "original" account to the taco truck, you can see chat working**
<img width="2075" height="870" alt="success" src="https://github.com/user-attachments/assets/644ccc90-b304-47c3-a9e4-581665511068" />

