### PR TITLE
Update case in package-lock.json to avoid trivial package-lock.json diffs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "node-emoji": "^1.10.0",
         "react": "^17",
         "react-ace": "^10.1.0",
-        "react-contextmenu": "git://github.com/roguelike-celebration/react-contextmenu#master",
+        "react-contextmenu": "git://github.com/Roguelike-Celebration/react-contextmenu#master",
         "react-dom": "^17",
         "react-firebaseui": "^5.0.2",
         "react-icons": "^3.10.0",
@@ -8394,7 +8394,7 @@
     },
     "node_modules/react-contextmenu": {
       "version": "2.14.0",
-      "resolved": "git+ssh://git@github.com/roguelike-celebration/react-contextmenu.git#91302c70578fb2896814139125bd1e7fda0d8c0b",
+      "resolved": "git+ssh://git@github.com/Roguelike-Celebration/react-contextmenu.git#91302c70578fb2896814139125bd1e7fda0d8c0b",
       "license": "MIT",
       "dependencies": {
         "classnames": "^2.2.5",
@@ -16334,8 +16334,8 @@
       }
     },
     "react-contextmenu": {
-      "version": "git+ssh://git@github.com/roguelike-celebration/react-contextmenu.git#91302c70578fb2896814139125bd1e7fda0d8c0b",
-      "from": "react-contextmenu@git://github.com/roguelike-celebration/react-contextmenu#master",
+      "version": "git+ssh://git@github.com/Roguelike-Celebration/react-contextmenu.git#91302c70578fb2896814139125bd1e7fda0d8c0b",
+      "from": "react-contextmenu@git://github.com/Roguelike-Celebration/react-contextmenu#master",
       "requires": {
         "classnames": "^2.2.5",
         "object-assign": "^4.1.0"


### PR DESCRIPTION
In package-lock.json, updates the case of "Roguelike-Celebration" in the URLs for our forked react-contextmenu to match the new canonical case in package.json with capital "R" and "C". This avoids trivial diffs to package-lock.json introduced by doing a fresh `npm install`, like on a freshly cloned repo or after deleting the node_modules dir.

Fixes https://github.com/Roguelike-Celebration/azure-mud/issues/920.

The case change in package.json was done in 69355ea676fae56186b16e5e570ab23f123a8902 as part of URL updates, back in May 2025.