### PR TITLE
Fix license to be MIT in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint-rooms": "ts-node lintLinks.ts"
   },
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "engines": {
     "node": ">=16.0.0",


### PR DESCRIPTION
This code is intended to be MIT licensed, and the "ISC" license declaration in package.json was an accident left over from the `npm init` defaults, per Emilia's comment at https://github.com/Roguelike-Celebration/azure-mud/issues/921#issuecomment-3242944587.