### PR TITLE
Minor JSON syntax fix for roomData.json

### DIFF
--- a/server/src/rooms/data/roomData.json
+++ b/server/src/rooms/data/roomData.json
@@ -36,7 +36,7 @@
       "addNoteLinkText": "Add feedback",
       "addNotePrompt": "What feedback do you have about the social space itself?",
       "noteWallDescription": "Social Space Feedback"
-    },
+    }
   },  
   "futureHut": {
     "displayName": "Madam Chrysalia's Future Hut",


### PR DESCRIPTION
Remove extraneous trailing comma in roomData.json which may be technically invalid and cause some stricter JSON parsers to complain or fail.

See: https://github.com/Roguelike-Celebration/azure-mud/issues/932#issuecomment-3263503559