### PR TITLE
Rename "Make 2024 speaker" menu item to "Make Past Speaker"

### DIFF
--- a/src/components/NameView.tsx
+++ b/src/components/NameView.tsx
@@ -98,7 +98,7 @@ export default function NameView (props: Props) {
       }
       onClick={handlePastSpeaker}
     >
-    Make 2024 speaker
+    Make Past Speaker
     </MenuItem>
   ) : (
     ''


### PR DESCRIPTION
For genericity, as a temporary thing. In response to [Discord chat](https://discord.com/channels/757389683188695150/889709795102326814/1431709684259229716).

There's a more thorough thing in https://github.com/Roguelike-Celebration/azure-mud/pull/855 to handle year changes for speaker badges automatically.