### PR TITLE
Fix 'referrerPolicy' spelling in RoomView.tsx StreamEmbed

### DIFF
--- a/src/components/RoomView.tsx
+++ b/src/components/RoomView.tsx
@@ -271,7 +271,7 @@ export function StreamEmbed () {
         src="https://www.youtube.com/embed/D1XmLqzHYG0"
         frameBorder="0"
         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-        referrerpolicy="strict-origin-when-cross-origin"
+        referrerPolicy="strict-origin-when-cross-origin"
         allowFullScreen
       ></iframe>
       <iframe


### PR DESCRIPTION
Looks like the small-p "referrerpolicy" spelling is wrong, at least as far as some `tsc` stuff is concerned, and is causing a typecheck failure, like in [this run](https://github.com/Roguelike-Celebration/azure-mud/actions/runs/34068462120/job/101581305673?pr=981) for Nathan's PR #981.

<img width="952" height="188" alt="image" src="https://github.com/user-attachments/assets/9757c14a-2df5-4b9c-a7c9-0acf8c2347ca" />

You won't see the fix take effect in the checks for this PR, because there's still a lint failure on main, and a lint failure causes the typecheck step to be skipped, it seems. But if we merge this and then Nathan rebases NathanBranch5 on the new main, then the error should go away in his PR's checks.